### PR TITLE
Analytics via Automattic Tracks

### DIFF
--- a/GravatarApp.xcodeproj/project.pbxproj
+++ b/GravatarApp.xcodeproj/project.pbxproj
@@ -360,7 +360,8 @@
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_STRICT_MEMORY_SAFETY = NO;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -397,7 +398,8 @@
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_STRICT_MEMORY_SAFETY = NO;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 2.0;
 			};

--- a/GravatarApp.xcodeproj/project.pbxproj
+++ b/GravatarApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1E99F8A72DFBE7B500F892CD /* Analytics in Frameworks */ = {isa = PBXBuildFile; productRef = 1E99F8A62DFBE7B500F892CD /* Analytics */; };
 		1EDD7FD32DF9BD6A00E5F1B6 /* Gravatar in Frameworks */ = {isa = PBXBuildFile; productRef = 1EDD7FD22DF9BD6A00E5F1B6 /* Gravatar */; };
 /* End PBXBuildFile section */
 
@@ -21,6 +22,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1E99F8A42DFBE72900F892CD /* Analytics */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Analytics; path = Packages/Analytics; sourceTree = "<group>"; };
 		1EDD7F902DF9B94300E5F1B6 /* GravatarApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GravatarApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1EDD7F9E2DF9B94500E5F1B6 /* GravatarAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GravatarAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -43,6 +45,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1E99F8A72DFBE7B500F892CD /* Analytics in Frameworks */,
 				1EDD7FD32DF9BD6A00E5F1B6 /* Gravatar in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -62,6 +65,7 @@
 			children = (
 				1EDD7F922DF9B94300E5F1B6 /* GravatarApp */,
 				1EDD7FA12DF9B94500E5F1B6 /* GravatarAppTests */,
+				1E99F8A42DFBE72900F892CD /* Analytics */,
 				1EDD7F912DF9B94300E5F1B6 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -96,6 +100,7 @@
 			name = GravatarApp;
 			packageProductDependencies = (
 				1EDD7FD22DF9BD6A00E5F1B6 /* Gravatar */,
+				1E99F8A62DFBE7B500F892CD /* Analytics */,
 			);
 			productName = GravatarApp;
 			productReference = 1EDD7F902DF9B94300E5F1B6 /* GravatarApp.app */;
@@ -154,6 +159,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				1EDD7FD12DF9BD6A00E5F1B6 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */,
+				1E99F8A52DFBE7B500F892CD /* XCLocalSwiftPackageReference "Packages/Analytics" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 1EDD7F912DF9B94300E5F1B6 /* Products */;
@@ -473,6 +479,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		1E99F8A52DFBE7B500F892CD /* XCLocalSwiftPackageReference "Packages/Analytics" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/Analytics;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		1EDD7FD12DF9BD6A00E5F1B6 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -485,6 +498,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		1E99F8A62DFBE7B500F892CD /* Analytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Analytics;
+		};
 		1EDD7FD22DF9BD6A00E5F1B6 /* Gravatar */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 1EDD7FD12DF9BD6A00E5F1B6 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */;

--- a/GravatarApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GravatarApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1b55caf5324dd1e5423ec97682fc0c2a85035161babd453c3047ba7a467b8673",
+  "originHash" : "1adebab19111d581423a22e0afe571b2a52cbeda78edbf16864025fe1c70915f",
   "pins" : [
     {
       "identity" : "automattic-tracks-ios",

--- a/GravatarApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GravatarApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "a4b9c833663be0011e458dbad100ef01b3bf9754d5f3eabddf7b5262c0fd8cb2",
+  "originHash" : "1b55caf5324dd1e5423ec97682fc0c2a85035161babd453c3047ba7a467b8673",
   "pins" : [
+    {
+      "identity" : "automattic-tracks-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
+      "state" : {
+        "revision" : "437f586a62c07c6ceec9baf043237b2afe7ea1ac",
+        "version" : "3.5.2"
+      }
+    },
     {
       "identity" : "gravatar-sdk-ios",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,33 @@
       "state" : {
         "revision" : "dd58fcdeaa145191eb9870d8b19f26659393219f",
         "version" : "3.3.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "930b78a63f47549c81e6e63c9172584f7d3dfdd6",
+        "version" : "8.52.1"
+      }
+    },
+    {
+      "identity" : "swift-sodium",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jedisct1/swift-sodium",
+      "state" : {
+        "revision" : "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "uideviceidentifier",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/squarefrog/UIDeviceIdentifier",
+      "state" : {
+        "revision" : "4699794b08bb79a4d77785edaba6ea739e298e4b",
+        "version" : "2.3.0"
       }
     }
   ],

--- a/GravatarApp.xcodeproj/xcshareddata/xcschemes/GravatarApp.xcscheme
+++ b/GravatarApp.xcodeproj/xcshareddata/xcschemes/GravatarApp.xcscheme
@@ -47,7 +47,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = "IDELaunchSchemeLanguageRLO"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/GravatarApp.xcodeproj/xcshareddata/xcschemes/GravatarApp.xcscheme
+++ b/GravatarApp.xcodeproj/xcshareddata/xcschemes/GravatarApp.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1EDD7F8F2DF9B94300E5F1B6"
+               BuildableName = "GravatarApp.app"
+               BlueprintName = "GravatarApp"
+               ReferencedContainer = "container:GravatarApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1EDD7F9D2DF9B94500E5F1B6"
+               BuildableName = "GravatarAppTests.xctest"
+               BlueprintName = "GravatarAppTests"
+               ReferencedContainer = "container:GravatarApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "IDELaunchSchemeLanguageRLO"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1EDD7F8F2DF9B94300E5F1B6"
+            BuildableName = "GravatarApp.app"
+            BlueprintName = "GravatarApp"
+            ReferencedContainer = "container:GravatarApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1EDD7F8F2DF9B94300E5F1B6"
+            BuildableName = "GravatarApp.app"
+            BlueprintName = "GravatarApp"
+            ReferencedContainer = "container:GravatarApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/GravatarApp/EnvironmentValues.swift
+++ b/GravatarApp/EnvironmentValues.swift
@@ -3,18 +3,7 @@ import SwiftUI
 // MARK: - Analytics
 
 import Analytics
-extension EnvironmentValues {
-    var analytics: Analytics {
-        get {
-            self[AnalyticsKey.self]
-        }
-        set {
-            self[AnalyticsKey.self] = newValue
-        }
-    }
-}
 
-struct AnalyticsKey: EnvironmentKey {
-    @MainActor
-    static var defaultValue: Analytics { .init() }
+extension EnvironmentValues {
+    @Entry var analytics: Analytics = .init()
 }

--- a/GravatarApp/EnvironmentValues.swift
+++ b/GravatarApp/EnvironmentValues.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+// MARK: - Analytics
+
+import Analytics
+extension EnvironmentValues {
+    var analytics: Analytics {
+        get {
+            self[AnalyticsKey.self]
+        }
+        set {
+            self[AnalyticsKey.self] = newValue
+        }
+    }
+}
+
+struct AnalyticsKey: EnvironmentKey {
+    @MainActor
+    static var defaultValue: Analytics { .init() }
+}

--- a/GravatarApp/Welcome/ContentView.swift
+++ b/GravatarApp/Welcome/ContentView.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 import Gravatar
+import Analytics
 
 struct ContentView: View {
+    @Environment(\.analytics) var analytics
+
     @State private var displayName: String = ""
     @State private var email: String = ""
 
@@ -17,9 +20,11 @@ struct ContentView: View {
 
             Button("Fetch profile") {
                 fetchProfile()
+                analytics.track(WelcomeScreenEvent.authButtonPressed)
             }
             .buttonStyle(.borderedProminent)
-            Text("Display Name:").padding(.top)
+            Text("Display Name:")
+                .padding(.top)
             Text(displayName)
         }
         .padding()
@@ -30,9 +35,12 @@ struct ContentView: View {
         Task {
             do {
                 let profile = try await service.fetch(with: .email(email))
+                analytics.setUserId(email)
+                analytics.track(WelcomeScreenEvent.authSuccess)
                 displayName = profile.displayName
             } catch {
                 displayName = error.localizedDescription
+                analytics.track(WelcomeScreenEvent.authFailed(with: error.localizedDescription))
             }
         }
     }

--- a/GravatarApp/Welcome/WelcomeScreenEvent.swift
+++ b/GravatarApp/Welcome/WelcomeScreenEvent.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Analytics
+
+enum WelcomeScreenEvent {
+    static let authButtonPressed: AnalyticsEvent = AuthButtonPressed()
+    static let authSuccess: AnalyticsEvent = AuthSuccess()
+    static func authFailed(with error: String) -> AnalyticsEvent {
+        AuthFailed(properties: AuthFailed.Properties(error: error))
+    }
+}
+
+private struct AuthButtonPressed: AnalyticsEvent {
+    let name: String = "auth_button_pressed"
+    let properties: EventProperties? = nil
+}
+
+private struct AuthSuccess: AnalyticsEvent {
+    let name: String = "auth_success"
+    let properties: EventProperties? = nil
+}
+
+private struct AuthFailed: AnalyticsEvent {
+    struct Properties: Encodable, Sendable {
+        let error: String
+    }
+
+    var name: String = "auth_failed"
+    var properties: EventProperties?
+}

--- a/Packages/Analytics/.gitignore
+++ b/Packages/Analytics/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Packages/Analytics/Package.swift
+++ b/Packages/Analytics/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Analytics",
+    platforms: [
+        .iOS(.v16), .macOS(.v12), .visionOS(.v1)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "Analytics",
+            targets: ["Analytics"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS", from: "3.5.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "Analytics",
+            dependencies: [
+                .product(name: "AutomatticTracks", package: "Automattic-Tracks-iOS")
+            ]
+        ),
+        .testTarget(
+            name: "AnalyticsTests",
+            dependencies: ["Analytics"]
+        ),
+    ]
+)

--- a/Packages/Analytics/Sources/Analytics/Analytics.swift
+++ b/Packages/Analytics/Sources/Analytics/Analytics.swift
@@ -1,8 +1,8 @@
 import Foundation
 import AutomatticTracksEvents
+import AutomatticTracksModel
 import OSLog
 
-@MainActor
 public class Analytics {
     private let tracker: Tracker
     private let logger = Logger(subsystem: "com.gravatar", category: "gravatar.analytics")
@@ -13,13 +13,14 @@ public class Analytics {
         self.tracker.configure()
 
         updateUserProperties()
+        TracksLogging.delegate = LoggingDelegate()
     }
 
     public func track(_ event: AnalyticsEvent) {
         let properties = event.jsonProperties ?? [:]
         tracker.track(event.name, withCustomProperties: properties)
         #if DEBUG
-        logger.debug("➥ Tracking: \(event.name); properties: \(properties)")
+        logger.debug("🔹 Tracking: \(event.name); properties: \(properties)")
         #endif
     }
 
@@ -31,10 +32,6 @@ public class Analytics {
     private var defaultProperties: [String: AnyHashable] {
         [
             "user_is_logged_in": loggedInUserId != nil,
-
-            // Accessibility
-            "is_rtl_language": UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft,
-            "dynamic_font_size_category": UIApplication.shared.preferredContentSizeCategory.rawValue
         ]
     }
 }
@@ -42,7 +39,31 @@ public class Analytics {
 private extension Analytics {
     func updateUserProperties() {
         defaultProperties.forEach { (key: String, value: AnyHashable) in
-            self.tracker.setUserProperty(value, for: key)
+            tracker.setUserProperty(value, for: key)
         }
+    }
+}
+
+private class LoggingDelegate: NSObject, TracksLoggingDelegate {
+    private let logger = Logger(subsystem: "com.tracks", category: "gravatar.analytics.logger_delegate")
+
+    func logError(_ str: String) {
+        logger.error("‼️ \(str)")
+    }
+
+    func logWarning(_ str: String) {
+        logger.warning("⚠️ \(str)")
+    }
+
+    func logInfo(_ str: String) {
+        logger.info("🔸 \(str)")
+    }
+
+    func logDebug(_ str: String) {
+        logger.debug("🔸 \(str)")
+    }
+
+    func logVerbose(_ str: String) {
+        logger.log("🔸 \(str)")
     }
 }

--- a/Packages/Analytics/Sources/Analytics/Analytics.swift
+++ b/Packages/Analytics/Sources/Analytics/Analytics.swift
@@ -1,34 +1,6 @@
 import Foundation
-import AutomatticTracks
+import AutomatticTracksEvents
 import OSLog
-
-public protocol Tracker {
-    func track(_ name: String, withCustomProperties: [String: AnyHashable])
-    func setUserProperty(_ value: AnyHashable, for key: String)
-    func configure()
-}
-
-extension TracksService: Tracker {
-    private enum Config {
-        static let prefix = "gravatar_ios"
-        static let userKey = "gravatar:user_id"
-        static let platform = "gravatar"
-    }
-
-    public func track(_ name: String, withCustomProperties: [String : AnyHashable]) {
-        trackEventName(name, withCustomProperties: withCustomProperties)
-    }
-
-    public func setUserProperty(_ value: AnyHashable, for key: String) {
-        userProperties[key] = value
-    }
-
-    public func configure() {
-        platform = Config.platform
-        eventNamePrefix = Config.prefix
-        authenticatedUserTypeKey = Config.userKey
-    }
-}
 
 @MainActor
 public class Analytics {

--- a/Packages/Analytics/Sources/Analytics/Analytics.swift
+++ b/Packages/Analytics/Sources/Analytics/Analytics.swift
@@ -1,0 +1,76 @@
+import Foundation
+import AutomatticTracks
+import OSLog
+
+public protocol Tracker {
+    func track(_ name: String, withCustomProperties: [String: AnyHashable])
+    func setUserProperty(_ value: AnyHashable, for key: String)
+    func configure()
+}
+
+extension TracksService: Tracker {
+    private enum Config {
+        static let prefix = "gravatar_ios"
+        static let userKey = "gravatar:user_id"
+        static let platform = "gravatar"
+    }
+
+    public func track(_ name: String, withCustomProperties: [String : AnyHashable]) {
+        trackEventName(name, withCustomProperties: withCustomProperties)
+    }
+
+    public func setUserProperty(_ value: AnyHashable, for key: String) {
+        userProperties[key] = value
+    }
+
+    public func configure() {
+        platform = Config.platform
+        eventNamePrefix = Config.prefix
+        authenticatedUserTypeKey = Config.userKey
+    }
+}
+
+@MainActor
+public class Analytics {
+    private let tracker: Tracker
+    private let logger = Logger(subsystem: "com.gravatar", category: "gravatar.analytics")
+    private var loggedInUserId: String?
+
+    public init(tracker: Tracker? = nil) {
+        self.tracker = tracker ?? TracksService(contextManager: TracksContextManager())
+        self.tracker.configure()
+
+        updateUserProperties()
+    }
+
+    public func track(_ event: AnalyticsEvent) {
+        let properties = event.jsonProperties ?? [:]
+        tracker.track(event.name, withCustomProperties: properties)
+        #if DEBUG
+        logger.debug("➥ Tracking: \(event.name); properties: \(properties)")
+        #endif
+    }
+
+    public func setUserId(_ userId: String?) {
+        loggedInUserId = userId
+        updateUserProperties()
+    }
+
+    private var defaultProperties: [String: AnyHashable] {
+        [
+            "user_is_logged_in": loggedInUserId != nil,
+
+            // Accessibility
+            "is_rtl_language": UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft,
+            "dynamic_font_size_category": UIApplication.shared.preferredContentSizeCategory.rawValue
+        ]
+    }
+}
+
+private extension Analytics {
+    func updateUserProperties() {
+        defaultProperties.forEach { (key: String, value: AnyHashable) in
+            self.tracker.setUserProperty(value, for: key)
+        }
+    }
+}

--- a/Packages/Analytics/Sources/Analytics/Event.swift
+++ b/Packages/Analytics/Sources/Analytics/Event.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public typealias EventProperties = (any Encodable & Sendable)
+
+public protocol AnalyticsEvent: Sendable {
+    var name: String { get }
+    var properties: EventProperties? { get }
+}
+
+extension AnalyticsEvent {
+    var jsonProperties: [String: AnyHashable]? {
+        guard
+            let properties,
+            let data = try? JSONEncoder.snakeCaseEncoder.encode(properties)
+        else { return nil }
+
+        return (try? JSONSerialization.jsonObject(with: data)).flatMap { $0 as? [String: AnyHashable] }
+    }
+}
+
+private extension JSONEncoder {
+    static var snakeCaseEncoder: JSONEncoder {
+        let decoder = JSONEncoder()
+        decoder.keyEncodingStrategy = .convertToSnakeCase
+        return decoder
+    }
+}

--- a/Packages/Analytics/Sources/Analytics/Tracker.swift
+++ b/Packages/Analytics/Sources/Analytics/Tracker.swift
@@ -1,0 +1,29 @@
+import AutomatticTracksEvents
+
+public protocol Tracker {
+    func track(_ name: String, withCustomProperties: [String: AnyHashable])
+    func setUserProperty(_ value: AnyHashable, for key: String)
+    func configure()
+}
+
+extension TracksService: Tracker {
+    private enum Config {
+        static let prefix = "gravatar_ios"
+        static let userKey = "gravatar:user_id"
+        static let platform = "gravatar"
+    }
+
+    public func track(_ name: String, withCustomProperties: [String : AnyHashable]) {
+        trackEventName(name, withCustomProperties: withCustomProperties)
+    }
+
+    public func setUserProperty(_ value: AnyHashable, for key: String) {
+        userProperties[key] = value
+    }
+
+    public func configure() {
+        platform = Config.platform
+        eventNamePrefix = Config.prefix
+        authenticatedUserTypeKey = Config.userKey
+    }
+}

--- a/Packages/Analytics/Tests/AnalyticsTests/AnalyticsTests.swift
+++ b/Packages/Analytics/Tests/AnalyticsTests/AnalyticsTests.swift
@@ -1,0 +1,62 @@
+import Testing
+@testable import Analytics
+
+@MainActor
+@Test("Test analytics init configuration is called")
+func configurationCalled() async throws {
+    let tracker = TrackerMock()
+    _ = Analytics(tracker: tracker)
+    #expect(tracker.configureCalled == true)
+}
+
+@MainActor
+@Test("Test user is logged out on init")
+func userLoggedOut() async throws {
+    let tracker = TrackerMock()
+    _ = Analytics(tracker: tracker)
+    #expect(tracker.userProperties["user_is_logged_in"] as? Bool == false)
+}
+
+@MainActor
+@Test("Test user is logged in")
+func userLoggedIn() async throws {
+    let tracker = TrackerMock()
+    let analytics = Analytics(tracker: tracker)
+    analytics.setUserId("user")
+
+    #expect(tracker.userProperties["user_is_logged_in"] as? Bool == true)
+}
+
+@MainActor
+@Test("Test event is tracked")
+func eventIsTracked() async throws {
+    let tracker = TrackerMock()
+    let analytics = Analytics(tracker: tracker)
+    analytics.track(TestEvent())
+
+    #expect(tracker.eventTracked == TestEvent().name)
+}
+
+@MainActor
+@Test("Test event property is tracked with snake_case")
+func eventIsTrackedProperties() async throws {
+    let tracker = TrackerMock()
+    let analytics = Analytics(tracker: tracker)
+    analytics.track(TestEventWithProperties())
+
+    #expect(tracker.eventTracked == TestEventWithProperties().name)
+    #expect(tracker.propertiesTracked?["test_property_key"] as? String == "property_value")
+}
+
+struct TestEvent: AnalyticsEvent {
+    var name: String = "test_event"
+    let properties: EventProperties? = nil
+}
+
+struct TestEventWithProperties: AnalyticsEvent {
+    struct Properties: Encodable, Sendable {
+        let testPropertyKey: String
+    }
+    var name: String = "test_event_with_properties"
+    let properties: EventProperties? = Properties(testPropertyKey: "property_value")
+}

--- a/Packages/Analytics/Tests/AnalyticsTests/TrackerMock.swift
+++ b/Packages/Analytics/Tests/AnalyticsTests/TrackerMock.swift
@@ -1,0 +1,21 @@
+import Analytics
+
+final class TrackerMock: Tracker {
+    var eventTracked: String? = nil
+    var propertiesTracked: [String: AnyHashable]? = nil
+    var configureCalled = false
+    var userProperties: [String: AnyHashable] = [:]
+
+    func track(_ name: String, withCustomProperties: [String : AnyHashable]) {
+        eventTracked = name
+        propertiesTracked = withCustomProperties
+    }
+
+    func setUserProperty(_ value: AnyHashable, for key: String) {
+        userProperties[key] = value
+    }
+
+    func configure() {
+        configureCalled = true
+    }
+}


### PR DESCRIPTION
Closes GRA-185

## Description

This PR implements Automattic Tracks for analytics

I've put the effort on making the interface type-safe, and avoiding gigantic enum declarations.

`Analytics` is added to `EnvironmentValues` for easy access.

The usage looks like this:

```swift
analytics.track(WelcomeScreenEvent.authButtonPressed)
```

And the events declaration looks like this:

```swift
// One events file per screen (or app section), wrapping all related event in an enum for easy access
enum WelcomeScreenEvent {
    static let authButtonPressed: AnalyticsEvent = AuthButtonPressed()
}

// The event struct is a bit more verbose, but this allows easy type safety and avoid declaring property keys with strings.
// Declared as private to avoid populating the project with types.
private struct AuthButtonPressed: AnalyticsEvent {
    let name: String = "auth_button_pressed"
    let properties: EventProperties? = nil
}
```

An example of an event with properties:

Usage:
```swift
analytics.track(WelcomeScreenEvent.authFailed(with: error.localizedDescription))
```

Declaration:

```swift
enum WelcomeScreenEvent {
    static func authFailed(with error: String) -> AnalyticsEvent {
        AuthFailed(properties: AuthFailed.Properties(error: error))
    }
}

private struct AuthFailed: AnalyticsEvent {
    struct Properties: Encodable, Sendable {
        let error: String
    }

    var name: String = "auth_failed"
    var properties: EventProperties?
}
```

I intentionally avoided using generic type for `AnalyticsEvent` (generic on the properties type) to make it easy to declare properties as nil. Though it's probably not a big deal 🤔 

## Test:

**Note:** The event names and the actual current interaction on the app doesn't match. This is made for tests purposes only.

- Run the app
- Fetch the profile from an email
- Go to Tracks and search for the events 
  - Can search by event name: `gravatar_ios%` 
  - They might take 6~10 mins to appear
  - Send the app to background and foreground to force sending the events to tracks.
- Alternatively, check the tracks request with ProxyMate or similar 

