### PR TITLE
OAuth improvements

### DIFF
--- a/GravatarApp.xcodeproj/project.pbxproj
+++ b/GravatarApp.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -329,6 +330,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -372,7 +374,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
@@ -417,7 +419,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;

--- a/GravatarApp/Welcome/WelcomeView.swift
+++ b/GravatarApp/Welcome/WelcomeView.swift
@@ -48,7 +48,10 @@ struct WelcomeView: View {
 
     @ViewBuilder
     func errorView(with error: Error) -> some View {
-        Text(String(describing: error))
+        Text(String(describing: error)).onAppear {
+            // Temporary for dev purposes
+            print("Error: \(error)")
+        }
         Spacer()
     }
 

--- a/GravatarApp/Welcome/WelcomeView.swift
+++ b/GravatarApp/Welcome/WelcomeView.swift
@@ -48,7 +48,7 @@ struct WelcomeView: View {
 
     @ViewBuilder
     func errorView(with error: Error) -> some View {
-        Text(error.localizedDescription)
+        Text(String(describing: error))
         Spacer()
     }
 

--- a/Packages/OAuth/Package.swift
+++ b/Packages/OAuth/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "OAuth",
     platforms: [
-        .iOS(.v16), .macOS(.v12), .visionOS(.v1),
+        .iOS("17.4"), .macOS(.v12), .visionOS(.v1),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Packages/OAuth/Sources/OAuth/AuthSession/WebAuthenticationSession.swift
+++ b/Packages/OAuth/Sources/OAuth/AuthSession/WebAuthenticationSession.swift
@@ -6,23 +6,11 @@ final class WebAuthenticationSession: NSObject, Sendable {
 
     func authenticate(using url: URL, callbackURLComponents: URLComponents) async throws -> URL {
         try await withCheckedThrowingContinuation { continuation in
-            let session: ASWebAuthenticationSession
-            let completionHandler = authSessionCompletionHandler(with: continuation)
-
-            if #available(iOS 17.4, *) {
-                let callback = authSessionCallback(with: callbackURLComponents)
-                session = ASWebAuthenticationSession(
-                    url: url,
-                    callback: callback,
-                    completionHandler: completionHandler
-                )
-            } else {
-                session = ASWebAuthenticationSession(
-                    url: url,
-                    callbackURLScheme: callbackURLComponents.scheme,
-                    completionHandler: completionHandler
-                )
-            }
+            let session = ASWebAuthenticationSession(
+                url: url,
+                callback: authSessionCallback(with: callbackURLComponents),
+                completionHandler: authSessionCompletionHandler(with: continuation)
+            )
 
             Task { @MainActor in
                 await sessionStorage.save(session)

--- a/Packages/OAuth/Sources/OAuth/CallbackParser/CallbackParser.swift
+++ b/Packages/OAuth/Sources/OAuth/CallbackParser/CallbackParser.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 protocol CallbackParser: Sendable {
-    func parse(from callbackURL: URL) async -> AccessToken?
+    func parse(from callbackURL: URL) async throws(OAuthError) -> AccessToken
 }

--- a/Packages/OAuth/Sources/OAuth/CallbackParser/CodeCallbackParser.swift
+++ b/Packages/OAuth/Sources/OAuth/CallbackParser/CodeCallbackParser.swift
@@ -13,12 +13,12 @@ struct CodeCallbackParser: CallbackParser {
         self.urlSession = urlSession
     }
 
-    func parse(from callbackURL: URL) async -> AccessToken? {
+    func parse(from callbackURL: URL) async throws(OAuthError) -> AccessToken {
         guard let code = parseCode(from: callbackURL) else {
-            return nil
+            throw OAuthError.couldNotParseAccessCode(callbackURL.absoluteString)
         }
 
-        return try? await requestAccessToken(with: code)
+        return try await requestAccessToken(with: code)
     }
 
     func parseCode(from callbackURL: URL) -> String? {

--- a/Packages/OAuth/Sources/OAuth/CallbackParser/TokenCallbackParser.swift
+++ b/Packages/OAuth/Sources/OAuth/CallbackParser/TokenCallbackParser.swift
@@ -1,17 +1,21 @@
 import Foundation
 
 struct TokenCallbackParser: CallbackParser {
-    func parse(from callbackURL: URL) async -> AccessToken? {
+    func parse(from callbackURL: URL) async throws(OAuthError) -> AccessToken {
         guard
             let fragment = callbackURL.fragment(),
             let queryItems = URLComponents(string: "?" + fragment)?.queryItems
-        else { return nil }
+        else {
+            throw .couldNotParseAccessCode(callbackURL.absoluteString)
+        }
 
         let parameters = queryItems.reduce(into: [String: String]()) { result, item in
             result[item.name] = item.value
         }
 
-        guard let token = parameters["access_token"] else { return nil }
+        guard let token = parameters["access_token"] else {
+            throw .couldNotParseAccessCode(fragment)
+        }
 
         return .init(token: token)
     }

--- a/Packages/OAuth/Sources/OAuth/OAuthManager.swift
+++ b/Packages/OAuth/Sources/OAuth/OAuthManager.swift
@@ -52,10 +52,7 @@ public struct OAuthManager: Sendable {
     }
 
     func handleCallback(_ callbackURL: URL) async throws(OAuthError) -> AccessToken {
-        guard let token = await callbackParser.parse(from: callbackURL) else {
-            throw OAuthError.couldNotParseAccessCode(callbackURL.absoluteString)
-        }
-
+        let token = try await callbackParser.parse(from: callbackURL)
         await authenticationSession.cancel()
         return token
     }

--- a/Packages/OAuth/Tests/OAuthTests/CodeParserTests.swift
+++ b/Packages/OAuth/Tests/OAuthTests/CodeParserTests.swift
@@ -7,9 +7,9 @@ func codeParser() async throws {
     await Configuration.shared.setSecrets(.init(clientID: "", clientSecret: "", redirectURI: ""))
     let response = ["access_token": "ACCESS_TOKEN"]
     let parser = CodeCallbackParser(urlSession: URLSessionMock(returnBody: response))
-    let token = await parser.parse(from: URL(string: "https://example.com/callback?code=12345")!)
+    let token = try await parser.parse(from: URL(string: "https://example.com/callback?code=12345")!)
 
-    #expect(token?.token == "ACCESS_TOKEN")
+    #expect(token.token == "ACCESS_TOKEN")
 }
 
 struct URLSessionMock: URLSessionProtocol, @unchecked Sendable {


### PR DESCRIPTION
This PR simplifies the OAuth logic by setting the minimum iOS version target to 17.4, and removing support for earlier versions.

Also, some improvements on development error messages.

### To test:

- Run `make setup` or `make dev`.
- Open the newly created `Secrets/Secrets.swift` file and fill it with the apps secrets.
- Run the app
- Tap on the login button
- Complete the oauth flow on web
  - Check that the logged-in screen appears with the user display name.
- Close and restart the app
  - Check that the app persisted the logged in state
- Press log-out
  - Check that you are back to the welcome screen.      