### PR TITLE
Adding collapsed header view to avatar picker

### DIFF
--- a/GravatarApp.xcodeproj/project.pbxproj
+++ b/GravatarApp.xcodeproj/project.pbxproj
@@ -10,7 +10,8 @@
 		1E0B559C2E004C62005D8777 /* OAuth in Resources */ = {isa = PBXBuildFile; fileRef = 1E0B559B2E004C62005D8777 /* OAuth */; };
 		1E79E4D12E019CD8008D2640 /* OAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 1E79E4D02E019CD8008D2640 /* OAuth */; };
 		1E99F8A72DFBE7B500F892CD /* Analytics in Frameworks */ = {isa = PBXBuildFile; productRef = 1E99F8A62DFBE7B500F892CD /* Analytics */; };
-		1EA068002E0A993A00D1C900 /* Gravatar in Frameworks */ = {isa = PBXBuildFile; productRef = 1EA067FF2E0A993A00D1C900 /* Gravatar */; };
+		1EE237E82E0B146C0074663F /* Gravatar in Frameworks */ = {isa = PBXBuildFile; productRef = 1EE237E72E0B146C0074663F /* Gravatar */; };
+		1EE237EA2E0B146C0074663F /* GravatarUI in Frameworks */ = {isa = PBXBuildFile; productRef = 1EE237E92E0B146C0074663F /* GravatarUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,9 +54,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1EE237EA2E0B146C0074663F /* GravatarUI in Frameworks */,
 				1E79E4D12E019CD8008D2640 /* OAuth in Frameworks */,
 				1E99F8A72DFBE7B500F892CD /* Analytics in Frameworks */,
-				1EA068002E0A993A00D1C900 /* Gravatar in Frameworks */,
+				1EE237E82E0B146C0074663F /* Gravatar in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,7 +114,8 @@
 			packageProductDependencies = (
 				1E99F8A62DFBE7B500F892CD /* Analytics */,
 				1E79E4D02E019CD8008D2640 /* OAuth */,
-				1EA067FF2E0A993A00D1C900 /* Gravatar */,
+				1EE237E72E0B146C0074663F /* Gravatar */,
+				1EE237E92E0B146C0074663F /* GravatarUI */,
 			);
 			productName = GravatarApp;
 			productReference = 1EDD7F902DF9B94300E5F1B6 /* GravatarApp.app */;
@@ -172,7 +175,7 @@
 			packageReferences = (
 				1E99F8A52DFBE7B500F892CD /* XCLocalSwiftPackageReference "Packages/Analytics" */,
 				1E79E4CF2E019CD8008D2640 /* XCLocalSwiftPackageReference "Packages/OAuth" */,
-				1EA067FE2E0A993A00D1C900 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */,
+				1EE237E62E0B146C0074663F /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 1EDD7F912DF9B94300E5F1B6 /* Products */;
@@ -625,7 +628,7 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		1EA067FE2E0A993A00D1C900 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */ = {
+		1EE237E62E0B146C0074663F /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/Gravatar-SDK-iOS.git";
 			requirement = {
@@ -644,10 +647,15 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = Analytics;
 		};
-		1EA067FF2E0A993A00D1C900 /* Gravatar */ = {
+		1EE237E72E0B146C0074663F /* Gravatar */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1EA067FE2E0A993A00D1C900 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */;
+			package = 1EE237E62E0B146C0074663F /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */;
 			productName = Gravatar;
+		};
+		1EE237E92E0B146C0074663F /* GravatarUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1EE237E62E0B146C0074663F /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */;
+			productName = GravatarUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/GravatarApp.xcodeproj/project.pbxproj
+++ b/GravatarApp.xcodeproj/project.pbxproj
@@ -545,7 +545,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;

--- a/GravatarApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GravatarApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d4145283f13b2da5c7e6bf44272cdb2d2e8d26e9892aec4b1512da7abe0dd130",
+  "originHash" : "437adc9d79bbd65f1a26832e8f13a2ef3fffd3eb33063cdda86c8dde1cd94dce",
   "pins" : [
     {
       "identity" : "automattic-tracks-ios",

--- a/GravatarApp/AvatarPicker/AvatarPickerHeaderView.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerHeaderView.swift
@@ -1,0 +1,116 @@
+import GravatarUI
+import SwiftUI
+
+struct AvatarPickerHeaderView: View {
+    @Binding var profile: Profile
+
+    private var imageURL: URL? {
+        AvatarURL(
+            with: .hashID(profile.hash),
+            options: .init(preferredSize: .points(.circlesSize))
+        )?.url
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .bottom) {
+                backgroundImageView(with: geometry.size.width)
+
+                overlayColor
+                    .edgesIgnoringSafeArea(.all)
+
+                ZStack {
+                    HStack(alignment: .bottom) {
+                        Spacer()
+                        smallImageView()
+                        Spacer()
+                    }
+
+                    HStack {
+                        Spacer()
+                        EllipsisButton(action: {})
+                    }
+                }
+                .padding(.horizontal, .hPadding)
+                .padding(.bottom, .bottomPadding)
+            }
+            .frame(width: geometry.size.width, height: .headerHeight)
+        }.ignoresSafeArea()
+    }
+
+    private var overlayColor: Color {
+        .black
+            .opacity(0.2)
+    }
+
+    private func smallImageView() -> some View {
+        HeaderAvatarView(imageURL: imageURL, showLoading: true) {
+            Image(systemName: "person.circle")
+                .font(.system(size: .circlesSize, weight: .thin))
+                .circleElementSize()
+        }
+        .shape(
+            Circle(),
+            borderColor: overlayColor,
+            borderWidth: 1
+        )
+        .circleElementSize()
+    }
+
+    private func backgroundImageView(with: CGFloat) -> some View {
+        HeaderAvatarView(imageURL: imageURL, showLoading: false) {
+            Color.clear
+        }
+        .scaledToFill()
+        .frame(width: with, height: .headerHeight)
+        .blur(radius: 10)
+        .clipped()
+        .opacity(0.8)
+    }
+}
+
+#Preview {
+    AvatarPickerHeaderView(profile: .constant(.testProfile))
+}
+
+// MARK: - Constants
+
+extension CGFloat {
+    fileprivate static let headerHeight: CGFloat = 110
+    fileprivate static let circlesSize: CGFloat = 40
+    fileprivate static let hPadding: CGFloat = 16
+    fileprivate static let bottomPadding: CGFloat = 12
+}
+
+extension View {
+    fileprivate func circleElementSize() -> some View {
+        self.frame(width: .circlesSize, height: .circlesSize)
+    }
+}
+
+// MARK: - Helpers
+
+private struct HeaderAvatarView<Placeholder>: View where Placeholder: View {
+    let imageURL: URL?
+    let showLoading: Bool
+    let placeholderView: () -> Placeholder
+
+    var body: some View {
+        AvatarView(
+            url: imageURL,
+            placeholderView: {
+                placeholderView()
+            },
+            // TODO: Temporarely force refresh to try different avatars
+            forceRefresh: .constant(true),
+            loadingView: {
+                showLoading ?
+                    AnyView(ProgressView().progressViewStyle(.circular))
+                    :
+                    AnyView(EmptyView())
+            },
+            transaction:
+            Transaction(animation: .smooth)
+        )
+    }
+}

--- a/GravatarApp/AvatarPicker/AvatarPickerHeaderView.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerHeaderView.swift
@@ -69,9 +69,11 @@ struct AvatarPickerHeaderView: View {
     }
 }
 
+#if DEBUG
 #Preview {
     AvatarPickerHeaderView(profile: .constant(.testProfile))
 }
+#endif
 
 // MARK: - Constants
 

--- a/GravatarApp/AvatarPicker/ContentView.swift
+++ b/GravatarApp/AvatarPicker/ContentView.swift
@@ -16,7 +16,7 @@ struct ContentView: View {
         AvatarPickerHeaderView(profile: $profile)
         VStack(alignment: .center) {
             Spacer()
-            profileView(with: profile)
+            Text("Profile View")
             Button("Logout") {
                 onLogout()
             }
@@ -26,6 +26,8 @@ struct ContentView: View {
     }
 }
 
+#if DEBUG
 #Preview {
     ContentView(profile: .testProfile, onLogout: {})
 }
+#endif

--- a/GravatarApp/AvatarPicker/ContentView.swift
+++ b/GravatarApp/AvatarPicker/ContentView.swift
@@ -13,11 +13,14 @@ struct ContentView: View {
     }
 
     var body: some View {
-        VStack {
+        AvatarPickerHeaderView(profile: $profile)
+        VStack(alignment: .center) {
+            Spacer()
             profileView(with: profile)
             Button("Logout") {
                 onLogout()
             }
+            Spacer()
         }
         .padding()
     }
@@ -25,4 +28,8 @@ struct ContentView: View {
     func profileView(with profile: Profile) -> some View {
         Text(profile.displayName)
     }
+}
+
+#Preview {
+    ContentView(profile: .testProfile, onLogout: {})
 }

--- a/GravatarApp/RootTabView.swift
+++ b/GravatarApp/RootTabView.swift
@@ -84,6 +84,6 @@ struct BackgroundColorView<Content>: View where Content: View {
 
 #if DEBUG // Needed when we use `Profile.testProfile on Previews`
 #Preview {
-    RootTabView(profile: Profile.testProfile, onLogout: {})
+    RootTabView(profile: .testProfile, onLogout: {})
 }
 #endif

--- a/GravatarApp/SharedViews/EllipsisButton.swift
+++ b/GravatarApp/SharedViews/EllipsisButton.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct EllipsisButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: {
+            action()
+        }) {
+            Image(systemName: "ellipsis")
+                .foregroundColor(Color(uiColor: .systemBackground))
+                .frame(width: 24, height: 24)
+                .padding()
+        }
+        .frame(width: 40, height: 40)
+        .background(Color.black.opacity(0.2))
+        .clipShape(Circle())
+    }
+}
+
+struct EllipsisButton_Previews: PreviewProvider {
+    static var previews: some View {
+        EllipsisButton(action: {})
+    }
+}


### PR DESCRIPTION
Closes GRA-219

This PR adds a collapsed style header to the avatar picker view:

<img src="https://github.com/user-attachments/assets/7b2083c7-4841-4c86-a074-2af0116b71f0" width="40%">

### To test:

- Run the app
- Login if needed
  - Check that the header view looks as in the designs.
  - Check that the avatar load properly.
  - Try changing the avatar at some other place and running the app again.
    - Maybe in the future we should implement pull to refresh and/or refresh on coming back from background.
  - Try logout and login with another account .
