### PR TITLE
Add a network interceptor to handle session expired errors

### DIFF
--- a/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
@@ -39,14 +39,15 @@ class AvatarPickerViewModel: ObservableObject {
         authToken: String,
         profileService: Gravatar.ProfileService? = nil,
         avatarService: AvatarService? = nil,
-        imageDownloader: ImageDownloader? = nil
+        imageDownloader: ImageDownloader? = nil,
+        urlSession: URLSessionProtocol = GravatarURLSession.shared
     ) {
         self.profile = profile
         avatarIdentifier = .hashID(profile.hash)
         self.authToken = authToken
-        self.profileService = profileService ?? Gravatar.ProfileService()
-        self.avatarService = avatarService ?? AvatarService()
-        self.imageDownloader = imageDownloader ?? ImageDownloadService()
+        self.profileService = profileService ?? Gravatar.ProfileService(urlSession: urlSession)
+        self.avatarService = avatarService ?? AvatarService(urlSession: urlSession)
+        self.imageDownloader = imageDownloader ?? ImageDownloadService(urlSession: urlSession)
 
         setupCombine()
     }

--- a/GravatarApp/CommonViewModels/ProfileViewModel.swift
+++ b/GravatarApp/CommonViewModels/ProfileViewModel.swift
@@ -5,15 +5,15 @@ import SwiftUI
 class ProfileViewModel: ObservableObject {
     @Published private(set) var isLoading: Bool = false
     @Published private(set) var profileResult: Result<Profile, APIError>?
-    private let profileService: ProfileServiceProtocol
+    private let profileService: ProfileService
     private let userDefaults: UserDefaults
 
     init(
         userDefaults: UserDefaults = .standard,
-        profileService: ProfileServiceProtocol = Gravatar.ProfileService()
+        urlSession: URLSessionProtocol = GravatarURLSession.shared,
     ) {
         self.userDefaults = userDefaults
-        self.profileService = profileService
+        self.profileService = ProfileService(urlSession: urlSession)
     }
 
     func fetchProfile(with token: String) async {
@@ -36,10 +36,3 @@ class ProfileViewModel: ObservableObject {
         profileResult = nil
     }
 }
-
-// Protocol for mocking in tests
-protocol ProfileServiceProtocol: Sendable {
-    func fetchOwnProfile(token: String) async throws -> Profile
-}
-
-extension Gravatar.ProfileService: ProfileServiceProtocol {}

--- a/GravatarApp/Networking/GravatarURLSession.swift
+++ b/GravatarApp/Networking/GravatarURLSession.swift
@@ -17,18 +17,20 @@ final class GravatarURLSession: URLSessionProtocol, Sendable {
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         let result = try await urlSession.data(for: request)
         if let httpResponse = result.1 as? HTTPURLResponse,
-           httpResponse.statusCode == HTTPStatus.unauthorized.rawValue {
+           httpResponse.statusCode == HTTPStatus.unauthorized.rawValue
+        {
             Task { @MainActor in
                 NotificationCenter.default.post(name: .sessionExpired, object: nil)
             }
         }
         return result
     }
-    
+
     func upload(for request: URLRequest, from bodyData: Data) async throws -> (Data, URLResponse) {
         let result = try await urlSession.upload(for: request, from: bodyData)
         if let httpResponse = result.1 as? HTTPURLResponse,
-           httpResponse.statusCode == HTTPStatus.unauthorized.rawValue {
+           httpResponse.statusCode == HTTPStatus.unauthorized.rawValue
+        {
             Task { @MainActor in
                 NotificationCenter.default.post(name: .sessionExpired, object: nil)
             }

--- a/GravatarApp/Networking/GravatarURLSession.swift
+++ b/GravatarApp/Networking/GravatarURLSession.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Gravatar
+
+/// Intercepts the network requests to perform common operations.
+final class GravatarURLSession: URLSessionProtocol, Sendable {
+    static let shared = GravatarURLSession()
+    fileprivate let urlSession: URLSession
+
+    private init() {
+        self.urlSession = URLSession(
+            configuration: URLSessionConfiguration.default,
+            delegate: nil,
+            delegateQueue: nil
+        )
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let result = try await urlSession.data(for: request)
+        if let httpResponse = result.1 as? HTTPURLResponse,
+           httpResponse.statusCode == HTTPStatus.unauthorized.rawValue {
+            Task { @MainActor in
+                NotificationCenter.default.post(name: .sessionExpired, object: nil)
+            }
+        }
+        return result
+    }
+    
+    func upload(for request: URLRequest, from bodyData: Data) async throws -> (Data, URLResponse) {
+        let result = try await urlSession.upload(for: request, from: bodyData)
+        if let httpResponse = result.1 as? HTTPURLResponse,
+           httpResponse.statusCode == HTTPStatus.unauthorized.rawValue {
+            Task { @MainActor in
+                NotificationCenter.default.post(name: .sessionExpired, object: nil)
+            }
+        }
+        return result
+    }
+}

--- a/GravatarApp/ProfileEditor/EditProfileViewModel.swift
+++ b/GravatarApp/ProfileEditor/EditProfileViewModel.swift
@@ -21,7 +21,7 @@ class EditProfileViewModel: ObservableObject {
 
     init(
         userSession: UserSession,
-        urlSession: URLSessionProtocol? = nil
+        urlSession: URLSessionProtocol = GravatarURLSession.shared
     ) {
         self.userSession = userSession
         self.profileService = .init(urlSession: urlSession)

--- a/GravatarApp/ProfileEditor/EditProfileViewModel.swift
+++ b/GravatarApp/ProfileEditor/EditProfileViewModel.swift
@@ -46,10 +46,6 @@ class EditProfileViewModel: ObservableObject {
                 self.userSession.updateProfile(profile)
             }
             // TODO: Show success toast
-        } catch APIError.responseError(let .invalidHTTPStatusCode(response, _))
-            where response.statusCode == HTTPStatus.unauthorized.rawValue
-        {
-            NotificationCenter.default.post(name: .sessionExpired, object: nil)
         } catch {
             // TODO: Show error toast
         }

--- a/GravatarApp/Welcome/WelcomeView.swift
+++ b/GravatarApp/Welcome/WelcomeView.swift
@@ -7,7 +7,7 @@ struct WelcomeView: View {
 
     var body: some View {
         Group {
-            if viewModel.isLoading {
+            if (viewModel.hasUser && viewModel.profileResult == nil) || viewModel.isLoading {
                 ProgressView()
             } else if let profileResult = viewModel.profileResult,
                       let accessToken = viewModel.accessToken

--- a/GravatarApp/Welcome/WelcomeView.swift
+++ b/GravatarApp/Welcome/WelcomeView.swift
@@ -7,7 +7,7 @@ struct WelcomeView: View {
 
     var body: some View {
         Group {
-            if (viewModel.hasUser && viewModel.profileResult == nil) || viewModel.isLoading {
+            if viewModel.isLoading {
                 ProgressView()
             } else if let profileResult = viewModel.profileResult,
                       let accessToken = viewModel.accessToken
@@ -31,6 +31,8 @@ struct WelcomeView: View {
         switch profileResult {
         case .success(let profile):
             rootViewSuccess(accessToken: accessToken, profile: profile)
+        case .failure(APIError.responseError(let .invalidHTTPStatusCode(response, _))) where response.statusCode == HTTPStatus.unauthorized.rawValue:
+            loginView
         case .failure(let error):
             Text("Error fetching the profile: \(error)")
                 .padding()

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -94,8 +94,9 @@ class WelcomeViewModel: ObservableObject {
     }
 
     func logout() async {
-        guard let profile = profileResult?.value() else { return }
-        oauthManager.deleteToken(with: profile.hash)
+        if let profile = profileResult?.value() {
+            oauthManager.deleteToken(with: profile.hash)
+        }
         await analytics.setUserName(nil)
         withAnimation {
             self.accessToken = nil

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -94,9 +94,10 @@ class WelcomeViewModel: ObservableObject {
     }
 
     func logout() async {
-        if let profile = profileResult?.value() {
-            oauthManager.deleteToken(with: profile.hash)
+        if let userID = userDefaults.string(forKey: .Gravatar.currentUserKey) {
+            oauthManager.deleteToken(with: userID)
         }
+        userDefaults.set(nil, forKey: .Gravatar.currentUserKey)
         await analytics.setUserName(nil)
         withAnimation {
             self.accessToken = nil

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -32,12 +32,12 @@ class WelcomeViewModel: ObservableObject {
         oauthManager: OAuthManager = .shared,
         userDefaults: UserDefaults = .standard,
         analytics: Analytics = .shared,
-        profileService: ProfileServiceProtocol = Gravatar.ProfileService()
+        urlSession: URLSessionProtocol = GravatarURLSession.shared,
     ) {
         self.oauthManager = oauthManager
         self.analytics = analytics
         self.userDefaults = userDefaults
-        self.profileViewModel = .init(userDefaults: userDefaults, profileService: profileService)
+        self.profileViewModel = .init(userDefaults: userDefaults, urlSession: urlSession)
 
         initCombine()
     }


### PR DESCRIPTION
Closes GRA-436

## Description

Adds a URLSessionProtocol implementing singleton to intercept all networking requests so we don't have to handle session expired errors separately. We might need to revisit this approach when designs are more certain but it would be easy to remove it or define exceptions for certain endpoints.

Also, I noticed that we are stuck at the loading state in case the token was expired and the app is killed. So I also tried to fixed it.

## To test

When in a logged in state
Expire your token via https://wordpress.com/me/security/connected-applications
Try any operation
Observe that you land on login

Log in
Expire your token via https://wordpress.com/me/security/connected-applications
Kill the app
Reopen the app
Observe that you land on login
