### PR TITLE
Offline support

### DIFF
--- a/GravatarApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GravatarApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "836a6c1f59ccca7cc2a410d4156881da4efbded0acf8657b79c1288717ea525b",
+  "originHash" : "437adc9d79bbd65f1a26832e8f13a2ef3fffd3eb33063cdda86c8dde1cd94dce",
   "pins" : [
     {
       "identity" : "automattic-tracks-ios",

--- a/GravatarApp/AppRoot/GravatarAppApp.swift
+++ b/GravatarApp/AppRoot/GravatarAppApp.swift
@@ -1,11 +1,25 @@
 import OAuth
+import SwiftData
 import SwiftUI
 
 @main
 struct GravatarAppApp: App {
+    var modelContext: ModelContext
+    @State private var unrecoberableError: Error?
+
+    init() {
+        do {
+            self.modelContext = try ModelContext(ModelContainer(for: ProfileStore.self))
+        } catch {
+            print("Error creating model context: \(error)")
+            resetSwiftDataStore()
+            modelContext = try! ModelContext(ModelContainer(for: ProfileStore.self))
+        }
+    }
+
     var body: some Scene {
         WindowGroup {
-            WelcomeView()
+            WelcomeView(modelContext: modelContext)
                 .configureOAuth(
                     clientID: Secrets.clientID,
                     clientSecret: Secrets.clientSecret,
@@ -17,5 +31,21 @@ struct GravatarAppApp: App {
                     UITabBar.appearance().scrollEdgeAppearance = appearance
                 }
         }
+    }
+}
+
+private func resetSwiftDataStore() {
+    let fileManager = FileManager.default
+    let storeURL = URL.applicationSupportDirectory.appending(path: "default.store")
+
+    if fileManager.fileExists(atPath: storeURL.path) {
+        do {
+            try fileManager.removeItem(at: storeURL)
+            print("✅ SwiftData store deleted.")
+        } catch {
+            print("❌ Error deleting SwiftData store: \(error)")
+        }
+    } else {
+        print("❌ Error deleting SwiftData store: Could not find store file.")
     }
 }

--- a/GravatarApp/AppRoot/RootTabView.swift
+++ b/GravatarApp/AppRoot/RootTabView.swift
@@ -1,4 +1,5 @@
 import Gravatar
+import SwiftData
 import SwiftUI
 
 struct RootTabView: View {
@@ -9,12 +10,11 @@ struct RootTabView: View {
 
     let onLogout: () -> Void
 
-    init(accessToken: String, profile: Profile, onLogout: @escaping () -> Void) {
-        let session = UserSession(profile: profile, accessToken: accessToken)
-        self.session = session
+    init(userSession: UserSession, context: ModelContext, onLogout: @escaping () -> Void) {
+        self.session = userSession
 
-        _avatarPickerViewModel = StateObject(wrappedValue: AvatarPickerViewModel(profile: profile, authToken: accessToken))
-        _editProfileViewModel = StateObject(wrappedValue: EditProfileViewModel(userSession: session))
+        _avatarPickerViewModel = StateObject(wrappedValue: AvatarPickerViewModel(profile: userSession.profile, authToken: userSession.accessToken))
+        _editProfileViewModel = StateObject(wrappedValue: EditProfileViewModel(userSession: userSession))
         self.onLogout = onLogout
     }
 
@@ -26,7 +26,7 @@ struct RootTabView: View {
 
             // MARK: - Second tab
 
-            ProfileTab(editProfileViewModel: editProfileViewModel)
+            ProfileTab(editProfileViewModel: editProfileViewModel, userSession: session)
 
             // MARK: - Third tab
 
@@ -58,7 +58,7 @@ struct GravatarTab: View {
 
 struct ProfileTab: View {
     @ObservedObject var editProfileViewModel: EditProfileViewModel
-    @EnvironmentObject var userSession: UserSession
+    let userSession: UserSession
 
     var body: some View {
         BackgroundColorView(color: .secondarySystemBackground) {
@@ -115,7 +115,8 @@ struct BackgroundColorView<Content>: View where Content: View {
 #if DEBUG // Needed when we use `Profile.testProfile on Previews`
 #Preview {
     RootTabView(
-        accessToken: "", profile: .testProfile,
+        userSession: UserSession(profile: .testProfile, accessToken: "", context: .testContext),
+        context: .testContext,
         onLogout: {}
     )
 }

--- a/GravatarApp/AppRoot/RootTabView.swift
+++ b/GravatarApp/AppRoot/RootTabView.swift
@@ -14,8 +14,8 @@ struct RootTabView: View {
         self.session = userSession
         self.onLogout = onLogout
 
-        _avatarPickerViewModel = StateObject(wrappedValue: AvatarPickerViewModel(userSession: session))
-        _editProfileViewModel = StateObject(wrappedValue: EditProfileViewModel(userSession: session))        
+        _avatarPickerViewModel = StateObject(wrappedValue: AvatarPickerViewModel(userSession: userSession))
+        _editProfileViewModel = StateObject(wrappedValue: EditProfileViewModel(userSession: userSession))
     }
 
     var body: some View {

--- a/GravatarApp/AppRoot/RootTabView.swift
+++ b/GravatarApp/AppRoot/RootTabView.swift
@@ -26,7 +26,7 @@ struct RootTabView: View {
 
             // MARK: - Second tab
 
-            ProfileTab(editProfileViewModel: editProfileViewModel, userSession: session)
+            ProfileTab(editProfileViewModel: editProfileViewModel)
 
             // MARK: - Third tab
 
@@ -58,11 +58,12 @@ struct GravatarTab: View {
 
 struct ProfileTab: View {
     @ObservedObject var editProfileViewModel: EditProfileViewModel
-    let userSession: UserSession
+
+    @EnvironmentObject var session: UserSession
 
     var body: some View {
         BackgroundColorView(color: .secondarySystemBackground) {
-            content(editProfileViewModel: editProfileViewModel, userSession: userSession)
+            content(editProfileViewModel: editProfileViewModel, userSession: session)
         }
         .ignoresSafeArea()
         .tabItem {

--- a/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
@@ -55,7 +55,7 @@ class AvatarPickerViewModel: ObservableObject {
 
     #if DEBUG
     static func preview_init(avatars: [AvatarImageModel] = []) -> AvatarPickerViewModel {
-        let model = AvatarPickerViewModel(userSession: UserSession(profile: .testProfile, accessToken: ""))
+        let model = AvatarPickerViewModel(userSession: UserSession(profile: .testProfile, accessToken: "", context: .testContext))
         model.grid = .init(avatars: avatars, selectedAvatar: avatars.first(where: { $0.isSelected }))
         model.setupCombine()
         return model

--- a/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
@@ -19,6 +19,8 @@ class AvatarPickerViewModel: ObservableObject {
         }
     }
 
+    private var networkMonitor: any NetworkMonitor
+
     @Published var profile: Profile
 
     @Published var selectedAvatarURL: URL?
@@ -39,7 +41,8 @@ class AvatarPickerViewModel: ObservableObject {
         authToken: String,
         profileService: Gravatar.ProfileService? = nil,
         avatarService: AvatarService? = nil,
-        imageDownloader: ImageDownloader? = nil
+        imageDownloader: ImageDownloader? = nil,
+        networkMonitor: any NetworkMonitor = SystemNetworkMonitor.shared
     ) {
         self.profile = profile
         avatarIdentifier = .hashID(profile.hash)
@@ -47,6 +50,7 @@ class AvatarPickerViewModel: ObservableObject {
         self.profileService = profileService ?? Gravatar.ProfileService()
         self.avatarService = avatarService ?? AvatarService()
         self.imageDownloader = imageDownloader ?? ImageDownloadService()
+        self.networkMonitor = networkMonitor
 
         setupCombine()
     }
@@ -76,6 +80,14 @@ class AvatarPickerViewModel: ObservableObject {
                 self?.shouldDisplayNoSelectedAvatarWarning = shouldShowWarning
             }
             .store(in: &cancellables)
+
+        networkMonitor.hasNetworkConnection.dropFirst().sink { [weak self] newValue in
+            if newValue && self?.gridResponseStatus?.error() != nil {
+                Task {
+                    await self?.fetchAvatars()
+                }
+            }
+        }.store(in: &cancellables)
     }
 
     func selectAvatar(with id: String) async -> AvatarDetails? {

--- a/GravatarApp/CommonViewModels/ProfileStore.swift
+++ b/GravatarApp/CommonViewModels/ProfileStore.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Gravatar
+import SwiftData
+
+@Model
+class ProfileStore {
+    @Attribute(.unique) var userHash: String
+    @Attribute var profileDescription: Data
+
+    var profile: Profile? {
+        do {
+            return try JSONDecoder().decode(Profile.self, from: profileDescription)
+        } catch {
+            return nil
+        }
+    }
+
+    init(profile: Profile) {
+        self.userHash = profile.hash
+        do {
+            profileDescription = try JSONEncoder().encode(profile)
+        } catch {
+            self.profileDescription = Data()
+        }
+    }
+}

--- a/GravatarApp/CommonViewModels/ProfileViewModel.swift
+++ b/GravatarApp/CommonViewModels/ProfileViewModel.swift
@@ -36,3 +36,10 @@ class ProfileViewModel: ObservableObject {
         profileResult = nil
     }
 }
+
+// Protocol for mocking in tests
+protocol ProfileServiceProtocol: Sendable {
+    func fetchOwnProfile(token: String) async throws -> Profile
+}
+
+extension Gravatar.ProfileService: ProfileServiceProtocol {}

--- a/GravatarApp/CommonViewModels/UserData.swift
+++ b/GravatarApp/CommonViewModels/UserData.swift
@@ -1,17 +1,25 @@
 import Combine
 import Gravatar
+import SwiftData
 
 @MainActor
 class UserSession: ObservableObject {
     @Published var profile: Profile
     @Published var accessToken: String
 
-    init(profile: Profile, accessToken: String) {
+    var context: ModelContext
+
+    init(profile: Profile, accessToken: String, context: ModelContext) {
         self.profile = profile
         self.accessToken = accessToken
+        self.context = context
     }
 
     func updateProfile(_ profile: Profile) {
+        guard self.profile != profile else { return }
+
         self.profile = profile
+        context.insert(ProfileStore(profile: profile))
+        context.saveNow()
     }
 }

--- a/GravatarApp/Extensions/ModelContext+extensions.swift
+++ b/GravatarApp/Extensions/ModelContext+extensions.swift
@@ -1,0 +1,11 @@
+import SwiftData
+
+extension ModelContext {
+    func saveNow() {
+        do {
+            try save()
+        } catch {
+            print("Error trying to save the context: \(error)")
+        }
+    }
+}

--- a/GravatarApp/Extensions/ModelContext+extensions.swift
+++ b/GravatarApp/Extensions/ModelContext+extensions.swift
@@ -9,3 +9,12 @@ extension ModelContext {
         }
     }
 }
+
+extension ModelContext {
+    @MainActor
+    static var testContext: ModelContext {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: ProfileStore.self, configurations: config)
+        return container.mainContext
+    }
+}

--- a/GravatarApp/Networking/NetworkMonitor.swift
+++ b/GravatarApp/Networking/NetworkMonitor.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Network
+import Observation
+
+@MainActor
+protocol NetworkMonitor: Sendable {
+    var hasNetworkConnection: Published<Bool>.Publisher { get }
+}
+
+@MainActor
+final class SystemNetworkMonitor: NetworkMonitor {
+    static let shared = SystemNetworkMonitor()
+
+    @Published private var internalHasNetworkConnection: Bool = true
+
+    var hasNetworkConnection: Published<Bool>.Publisher { $internalHasNetworkConnection }
+
+    private let networkMonitor = NWPathMonitor()
+
+    private init() {
+        networkMonitor.pathUpdateHandler = { [weak self] path in
+            Task {
+                await self?.updateNetworkConnectionStatus(to: path.status == .satisfied)
+            }
+        }
+
+        networkMonitor.start(queue: DispatchQueue.global())
+    }
+
+    private func updateNetworkConnectionStatus(to newStatus: Bool) async {
+        guard internalHasNetworkConnection != newStatus else { return }
+        internalHasNetworkConnection = newStatus
+    }
+}

--- a/GravatarApp/ProfileEditor/EditProfileViewModel.swift
+++ b/GravatarApp/ProfileEditor/EditProfileViewModel.swift
@@ -11,6 +11,8 @@ class EditProfileViewModel: ObservableObject {
     @Published var isSaving: Bool = false
     @Published var fields: ProfileFieldsModel
 
+    private var networkMonitor: any NetworkMonitor
+
     var isSavinDisabled: Bool {
         !hasUnsavedChanges || isSaving
     }
@@ -21,17 +23,30 @@ class EditProfileViewModel: ObservableObject {
 
     init(
         userSession: UserSession,
-        urlSession: URLSessionProtocol? = nil
+        urlSession: URLSessionProtocol? = nil,
+        networkMonitor: any NetworkMonitor = SystemNetworkMonitor.shared
     ) {
         self.userSession = userSession
         self.profileService = .init(urlSession: urlSession)
+        self.networkMonitor = networkMonitor
 
         self.fields = .init(profile: userSession.profile)
 
+        setupCombine()
+    }
+
+    private func setupCombine() {
         userSession.$profile.sink { [weak self] profile in
             self?.fields = .init(profile: profile)
         }
         .store(in: &cancellables)
+        networkMonitor.hasNetworkConnection.dropFirst().sink { [weak self] newValue in
+            if newValue {
+                Task {
+                    await self?.fetchProfile()
+                }
+            }
+        }.store(in: &cancellables)
     }
 
     func save() async {
@@ -43,7 +58,7 @@ class EditProfileViewModel: ObservableObject {
             let request = fields.updateRequest()
             let profile = try await profileService.updateProfile(with: request, token: userSession.accessToken)
             Task { @MainActor in
-                self.userSession.updateProfile(profile)
+                userSession.updateProfile(profile)
             }
             // TODO: Show success toast
         } catch APIError.responseError(let .invalidHTTPStatusCode(response, _))
@@ -53,5 +68,12 @@ class EditProfileViewModel: ObservableObject {
         } catch {
             // TODO: Show error toast
         }
+    }
+
+    func fetchProfile() async {
+        do {
+            let profile = try await profileService.fetchOwnProfile(token: userSession.accessToken)
+            userSession.updateProfile(profile)
+        } catch {}
     }
 }

--- a/GravatarApp/ProfileEditor/ProfileHeaderContentView.swift
+++ b/GravatarApp/ProfileEditor/ProfileHeaderContentView.swift
@@ -233,16 +233,6 @@ class ProfileHeaderContentView: UIView, CollapsableHeaderViewContent {
 }
 
 #if DEBUG
-import SwiftData
-
-extension ModelContext {
-    @MainActor
-    static var testContext: ModelContext {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try! ModelContainer(for: ProfileStore.self, configurations: config)
-        return container.mainContext
-    }
-}
 
 #Preview("Max height") {
     let userSession = UserSession(profile: .testProfile, accessToken: "", context: .testContext)

--- a/GravatarApp/ProfileEditor/ProfileHeaderContentView.swift
+++ b/GravatarApp/ProfileEditor/ProfileHeaderContentView.swift
@@ -8,12 +8,6 @@ class ProfileHeaderContentView: UIView, CollapsableHeaderViewContent {
         static let backgroundColorCollapsed = UIColor.systemBackground
     }
 
-    var profile: Profile? {
-        didSet {
-            updateProfileData()
-        }
-    }
-
     weak var delegate: (any CollapsableHeaderViewContentDelegate)?
 
     private let userSession: UserSession
@@ -71,7 +65,6 @@ class ProfileHeaderContentView: UIView, CollapsableHeaderViewContent {
 
     required init(userSession: UserSession) {
         self.userSession = userSession
-        self.profile = userSession.profile
 
         super.init(frame: .zero)
         self.translatesAutoresizingMaskIntoConstraints = false
@@ -81,12 +74,13 @@ class ProfileHeaderContentView: UIView, CollapsableHeaderViewContent {
         }
 
         initConstraints()
-        updateProfileData()
+        update(with: userSession.profile)
         userSession.$profile.sink { [weak self] profile in
             guard let self else { return }
-            self.profile = profile
+
+            update(with: profile)
             // Recreate the animator otherwise text alignments get messed up
-            self.delegate?.didUpdateData(self)
+            delegate?.didUpdateData(self)
         }
         .store(in: &cancellables)
     }
@@ -155,8 +149,7 @@ class ProfileHeaderContentView: UIView, CollapsableHeaderViewContent {
         nameLabelExpanded.alpha = collapsed ? 0 : 1
     }
 
-    private func updateProfileData() {
-        guard let profile else { return }
+    private func update(with profile: Profile) {
         nameLabelExpanded.text = profile.displayName
         nameLabelCollapsed.text = profile.displayName
         organisationLabelExpanded.text = "\(profile.jobTitle), \(profile.company)"
@@ -240,8 +233,19 @@ class ProfileHeaderContentView: UIView, CollapsableHeaderViewContent {
 }
 
 #if DEBUG
+import SwiftData
+
+extension ModelContext {
+    @MainActor
+    static var testContext: ModelContext {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: ProfileStore.self, configurations: config)
+        return container.mainContext
+    }
+}
+
 #Preview("Max height") {
-    let userSession = UserSession(profile: .testProfile, accessToken: "")
+    let userSession = UserSession(profile: .testProfile, accessToken: "", context: .testContext)
     let view = ProfileHeaderContentView(userSession: userSession)
     view.updateUI(for: .fullHeight)
     view.interpolate(with: 0)
@@ -249,7 +253,7 @@ class ProfileHeaderContentView: UIView, CollapsableHeaderViewContent {
 }
 
 #Preview("Min height") {
-    let userSession = UserSession(profile: .testProfile, accessToken: "")
+    let userSession = UserSession(profile: .testProfile, accessToken: "", context: .testContext)
     let view = ProfileHeaderContentView(userSession: userSession)
     view.updateUI(for: .minHeight)
     view.interpolate(with: 1)

--- a/GravatarApp/UIComponents/CollapsableHeader/CollapsableHeaderView.swift
+++ b/GravatarApp/UIComponents/CollapsableHeader/CollapsableHeaderView.swift
@@ -88,7 +88,6 @@ class CollapsableHeaderView: UIView, CollapsableHeaderViewContentDelegate {
         let currentWidth = bounds.width
         if currentWidth != lastWidth {
             if lastWidth != 0 {
-                print("Width changed to: \(currentWidth)")
                 handleWidthChange()
             }
             lastWidth = currentWidth

--- a/GravatarApp/Welcome/WelcomeView.swift
+++ b/GravatarApp/Welcome/WelcomeView.swift
@@ -78,6 +78,6 @@ extension String {
     }
 }
 
-// #Preview {
-//    WelcomeView()
-// }
+ #Preview {
+     WelcomeView(modelContext: .testContext)
+ }

--- a/GravatarApp/Welcome/WelcomeView.swift
+++ b/GravatarApp/Welcome/WelcomeView.swift
@@ -14,12 +14,9 @@ struct WelcomeView: View {
 
     var body: some View {
         Group {
-            if
-                let profileResult = viewModel.profileResult,
-                let userSession = viewModel.userSession
-            {
-                rootView(profileResult: profileResult, userSession: userSession)
-            } else if (viewModel.hasUser && viewModel.profileResult == nil) || viewModel.isLoading {
+            if let userSession = viewModel.userSession {
+                rootView(userSession: userSession)
+            } else if viewModel.hasUser || viewModel.isLoading {
                 ProgressView()
             } else {
                 loginView
@@ -36,18 +33,7 @@ struct WelcomeView: View {
         }
     }
 
-    @ViewBuilder
-    private func rootView(profileResult: Result<Profile, APIError>, userSession: UserSession) -> some View {
-        switch profileResult {
-        case .success:
-            rootViewSuccess(userSession: userSession)
-        case .failure(let error):
-            Text("Error fetching the profile: \(error)")
-                .padding()
-        }
-    }
-
-    private func rootViewSuccess(userSession: UserSession) -> some View {
+    private func rootView(userSession: UserSession) -> some View {
         RootTabView(userSession: userSession, context: modelContext) {
             Task {
                 await viewModel.logout()
@@ -69,6 +55,8 @@ struct WelcomeView: View {
             }.buttonStyle(.borderedProminent)
             Spacer()
             if let error = viewModel.oauthError {
+                errorView(with: error)
+            } else if let error = viewModel.profileFetchingError {
                 errorView(with: error)
             }
         }

--- a/GravatarApp/Welcome/WelcomeView.swift
+++ b/GravatarApp/Welcome/WelcomeView.swift
@@ -1,22 +1,32 @@
 import Gravatar
 import OAuth
+import SwiftData
 import SwiftUI
 
 struct WelcomeView: View {
-    @StateObject private var viewModel: WelcomeViewModel = .init()
+    @StateObject private var viewModel: WelcomeViewModel
+    private var modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+        _viewModel = .init(wrappedValue: WelcomeViewModel(context: modelContext))
+    }
 
     var body: some View {
         Group {
-            if (viewModel.hasUser && viewModel.profileResult == nil) || viewModel.isLoading {
-                ProgressView()
-            } else if let profileResult = viewModel.profileResult,
-                      let accessToken = viewModel.accessToken
+            if
+                let profileResult = viewModel.profileResult,
+                let userSession = viewModel.userSession
             {
-                rootView(accessToken: accessToken, profileResult: profileResult)
+                rootView(profileResult: profileResult, userSession: userSession)
+            } else if (viewModel.hasUser && viewModel.profileResult == nil) || viewModel.isLoading {
+                ProgressView()
             } else {
                 loginView
             }
-        }.onAppear {
+        }
+        .modelContext(modelContext)
+        .onAppear {
             viewModel.softLogin()
         }
         .onReceive(NotificationCenter.default.publisher(for: .sessionExpired)) { _ in
@@ -27,18 +37,18 @@ struct WelcomeView: View {
     }
 
     @ViewBuilder
-    private func rootView(accessToken: String, profileResult: Result<Profile, APIError>) -> some View {
+    private func rootView(profileResult: Result<Profile, APIError>, userSession: UserSession) -> some View {
         switch profileResult {
-        case .success(let profile):
-            rootViewSuccess(accessToken: accessToken, profile: profile)
+        case .success:
+            rootViewSuccess(userSession: userSession)
         case .failure(let error):
             Text("Error fetching the profile: \(error)")
                 .padding()
         }
     }
 
-    private func rootViewSuccess(accessToken: String, profile: Profile) -> some View {
-        RootTabView(accessToken: accessToken, profile: profile) {
+    private func rootViewSuccess(userSession: UserSession) -> some View {
+        RootTabView(userSession: userSession, context: modelContext) {
             Task {
                 await viewModel.logout()
             }
@@ -80,6 +90,6 @@ extension String {
     }
 }
 
-#Preview {
-    WelcomeView()
-}
+// #Preview {
+//    WelcomeView()
+// }

--- a/GravatarApp/Welcome/WelcomeView.swift
+++ b/GravatarApp/Welcome/WelcomeView.swift
@@ -78,6 +78,6 @@ extension String {
     }
 }
 
- #Preview {
-     WelcomeView(modelContext: .testContext)
- }
+#Preview {
+    WelcomeView(modelContext: .testContext)
+}

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -3,6 +3,7 @@ import Combine
 import Foundation
 import Gravatar
 import OAuth
+import SwiftData
 import SwiftUI
 
 @MainActor
@@ -22,22 +23,27 @@ class WelcomeViewModel: ObservableObject {
     @Published var profileViewModel: ProfileViewModel
     @Published var profileResult: Result<Profile, APIError>?
     @Published var isLoading: Bool = false
+    @Published var userSession: UserSession?
 
     private var cancellables = Set<AnyCancellable>()
     private let oauthManager: OAuthManager
     private let analytics: Analytics
     private let userDefaults: UserDefaults
+    private let context: ModelContext
+    private var storedProfile: Profile?
 
     init(
         oauthManager: OAuthManager = .shared,
         userDefaults: UserDefaults = .standard,
         analytics: Analytics = .shared,
-        profileService: ProfileServiceProtocol = Gravatar.ProfileService()
+        profileService: ProfileServiceProtocol = Gravatar.ProfileService(),
+        context: ModelContext
     ) {
         self.oauthManager = oauthManager
         self.analytics = analytics
         self.userDefaults = userDefaults
         self.profileViewModel = .init(userDefaults: userDefaults, profileService: profileService)
+        self.context = context
 
         initCombine()
     }
@@ -66,15 +72,33 @@ class WelcomeViewModel: ObservableObject {
     private func handleProfileFetch(accessToken: String, profileResult newResult: Result<Profile, APIError>) {
         switch newResult {
         case .success(let profile):
-            self.oauthManager.saveToken(AccessToken(token: accessToken), withKey: profile.hash)
-            Task {
-                await analytics.setUserName(profile.userLogin)
-            }
+            configureSession(profile: profile, accessToken: accessToken)
         case .failure:
-            break
+            withAnimation {
+                if let storedProfile {
+                    // Continue with the stored profile
+                    configureSession(profile: storedProfile, accessToken: accessToken)
+                } else {
+                    profileResult = newResult
+                }
+            }
+        }
+    }
+
+    private func configureSession(profile: Profile, accessToken: String) {
+        self.oauthManager.saveToken(AccessToken(token: accessToken), withKey: profile.hash)
+        Task {
+            await analytics.setUserName(profile.userLogin)
         }
         withAnimation {
-            self.profileResult = newResult
+            if let userSession {
+                userSession.updateProfile(profile)
+            } else {
+                userSession = .init(profile: profile, accessToken: accessToken, context: context)
+                context.insert(ProfileStore(profile: profile))
+                context.saveNow()
+            }
+            profileResult = .success(profile)
         }
     }
 
@@ -83,6 +107,16 @@ class WelcomeViewModel: ObservableObject {
             let currentUser = userDefaults.string(forKey: .Gravatar.currentUserKey),
             let secureToken = oauthManager.sessionToken(with: currentUser)
         else { return }
+
+        let descriptor = FetchDescriptor<ProfileStore>(predicate: #Predicate { $0.userHash == currentUser })
+
+        if let profile = try? context.fetch(descriptor).first?.profile {
+            storedProfile = profile
+            configureSession(profile: profile, accessToken: secureToken.token)
+            withAnimation {
+                self.profileResult = .success(profile)
+            }
+        }
 
         self.accessToken = secureToken.token
     }
@@ -98,8 +132,9 @@ class WelcomeViewModel: ObservableObject {
         oauthManager.deleteToken(with: profile.hash)
         await analytics.setUserName(nil)
         withAnimation {
-            self.accessToken = nil
-            self.profileResult = nil
+            userSession = nil
+            accessToken = nil
+            profileResult = nil
             profileViewModel.removeResult()
         }
     }

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -22,7 +22,7 @@ class WelcomeViewModel: ObservableObject {
         oauthManager: OAuthManager = .shared,
         userDefaults: UserDefaults = .standard,
         analytics: Analytics = .shared,
-        profileService: ProfileServiceProtocol = Gravatar.ProfileService(),
+        profileService: ProfileServiceProtocol = Gravatar.ProfileService(urlSession: GravatarURLSession.shared),
         context: ModelContext
     ) {
         self.oauthManager = oauthManager

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -1,6 +1,4 @@
 import Analytics
-import Combine
-import Foundation
 import Gravatar
 import OAuth
 import SwiftData
@@ -10,27 +8,15 @@ import SwiftUI
 class WelcomeViewModel: ObservableObject {
     @Published var oauthError: Error?
     @Published var profileFetchingError: APIError?
-    @Published var accessToken: String? {
-        didSet {
-            if let accessToken, accessToken != oldValue {
-                Task {
-                    await self.profileViewModel.fetchProfile(with: accessToken)
-                }
-            }
-        }
-    }
 
-    @Published var profileViewModel: ProfileViewModel
-    @Published var profileResult: Result<Profile, APIError>?
     @Published var isLoading: Bool = false
     @Published var userSession: UserSession?
 
-    private var cancellables = Set<AnyCancellable>()
+    private let profileService: any ProfileServiceProtocol
     private let oauthManager: OAuthManager
     private let analytics: Analytics
     private let userDefaults: UserDefaults
     private let context: ModelContext
-    private var storedProfile: Profile?
 
     init(
         oauthManager: OAuthManager = .shared,
@@ -42,83 +28,57 @@ class WelcomeViewModel: ObservableObject {
         self.oauthManager = oauthManager
         self.analytics = analytics
         self.userDefaults = userDefaults
-        self.profileViewModel = .init(userDefaults: userDefaults, profileService: profileService)
+        self.profileService = profileService
         self.context = context
-
-        initCombine()
     }
 
-    private func initCombine() {
-        $accessToken
-            .combineLatest(profileViewModel.$profileResult)
-            .compactMap { accessToken, profileResult -> (String, Result<Profile, APIError>)? in
-                guard let accessToken, let profileResult else {
-                    return nil
-                }
-                return (accessToken, profileResult)
-            }
-            .sink { [weak self] newToken, profileResult in
-                guard let self else { return }
-                self.handleProfileFetch(accessToken: newToken, profileResult: profileResult)
-            }
-            .store(in: &cancellables)
-
-        profileViewModel.$isLoading.sink { [weak self] newValue in
-            self?.isLoading = newValue
+    func fetchProfile(with token: String) async {
+        defer {
+            isLoading = false
         }
-        .store(in: &cancellables)
-    }
-
-    private func handleProfileFetch(accessToken: String, profileResult newResult: Result<Profile, APIError>) {
-        switch newResult {
-        case .success(let profile):
-            configureSession(profile: profile, accessToken: accessToken)
-        case .failure:
-            withAnimation {
-                if let storedProfile {
-                    // Continue with the stored profile
-                    configureSession(profile: storedProfile, accessToken: accessToken)
-                } else {
-                    profileResult = newResult
-                }
-            }
+        do {
+            isLoading = true
+            let profile = try await profileService.fetchOwnProfile(token: token)
+            configureSession(profile: profile, accessToken: token)
+        } catch {
+            profileFetchingError = error as? APIError
         }
     }
 
     private func configureSession(profile: Profile, accessToken: String) {
         self.oauthManager.saveToken(AccessToken(token: accessToken), withKey: profile.hash)
+
         Task {
             await analytics.setUserName(profile.userLogin)
         }
-        withAnimation {
-            if let userSession {
-                userSession.updateProfile(profile)
-            } else {
+        userDefaults.set(profile.hash, forKey: .Gravatar.currentUserKey)
+
+        if let userSession {
+            userSession.updateProfile(profile)
+        } else {
+            withAnimation {
                 userSession = .init(profile: profile, accessToken: accessToken, context: context)
-                context.insert(ProfileStore(profile: profile))
-                context.saveNow()
             }
-            profileResult = .success(profile)
+            context.insert(ProfileStore(profile: profile))
+            context.saveNow()
         }
     }
 
     func softLogin() {
         guard
-            let currentUser = userDefaults.string(forKey: .Gravatar.currentUserKey),
-            let secureToken = oauthManager.sessionToken(with: currentUser)
+            let currentUserHash = userDefaults.string(forKey: .Gravatar.currentUserKey),
+            let accessToken = oauthManager.sessionToken(with: currentUserHash)?.token
         else { return }
 
-        let descriptor = FetchDescriptor<ProfileStore>(predicate: #Predicate { $0.userHash == currentUser })
+        let descriptor = FetchDescriptor<ProfileStore>(predicate: #Predicate { $0.userHash == currentUserHash })
 
-        if let profile = try? context.fetch(descriptor).first?.profile {
-            storedProfile = profile
-            configureSession(profile: profile, accessToken: secureToken.token)
-            withAnimation {
-                self.profileResult = .success(profile)
+        Task {
+            if let profile = try? context.fetch(descriptor).first?.profile {
+                configureSession(profile: profile, accessToken: accessToken)
             }
-        }
 
-        self.accessToken = secureToken.token
+            await fetchProfile(with: accessToken)
+        }
     }
 
     var hasUser: Bool {
@@ -128,14 +88,16 @@ class WelcomeViewModel: ObservableObject {
     }
 
     func logout() async {
-        guard let profile = profileResult?.value() else { return }
+        guard let profile = userSession?.profile else { return }
+
         oauthManager.deleteToken(with: profile.hash)
         await analytics.setUserName(nil)
+
+        try? context.delete(model: ProfileStore.self)
+        context.saveNow()
+
         withAnimation {
-            userSession = nil
-            accessToken = nil
-            profileResult = nil
-            profileViewModel.removeResult()
+            self.userSession = nil
         }
     }
 
@@ -143,10 +105,13 @@ class WelcomeViewModel: ObservableObject {
         analytics.track(WelcomeScreenEvent.authButtonPressed)
         oauthError = nil
         do {
-            self.accessToken = try await oauthManager.requestAccessToken().token
+            isLoading = true
+            let token = try await oauthManager.requestAccessToken().token
+            await fetchProfile(with: token)
             analytics.track(WelcomeScreenEvent.authSuccess)
         } catch {
             self.oauthError = error
+            isLoading = false
         }
     }
 }

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -72,11 +72,11 @@ class WelcomeViewModel: ObservableObject {
 
         let descriptor = FetchDescriptor<ProfileStore>(predicate: #Predicate { $0.userHash == currentUserHash })
 
-        Task {
-            if let profile = try? context.fetch(descriptor).first?.profile {
-                configureSession(profile: profile, accessToken: accessToken)
-            }
+        if let profile = try? context.fetch(descriptor).first?.profile {
+            configureSession(profile: profile, accessToken: accessToken)
+        }
 
+        Task {
             await fetchProfile(with: accessToken)
         }
     }

--- a/GravatarAppTests/AvatarTests/AvatarPickerViewModelTests.swift
+++ b/GravatarAppTests/AvatarTests/AvatarPickerViewModelTests.swift
@@ -19,7 +19,7 @@ final class AvatarPickerViewModelTests {
         networkMonitor: TestNetworkMonitor? = nil
     ) -> AvatarPickerViewModel {
         AvatarPickerViewModel(
-            userSession: UserSession(profile: .testProfile, accessToken: "token"),
+            userSession: UserSession(profile: .testProfile, accessToken: "token", context: .testContext),
             profileService: ProfileService(urlSession: session),
             avatarService: AvatarService(urlSession: session),
             imageDownloader: imageDownloader,

--- a/GravatarAppTests/AvatarTests/AvatarPickerViewModelTests.swift
+++ b/GravatarAppTests/AvatarTests/AvatarPickerViewModelTests.swift
@@ -15,14 +15,16 @@ final class AvatarPickerViewModelTests {
 
     static func createModel(
         session: URLSessionProtocol = URLSessionAvatarPickerMock(),
-        imageDownloader: ImageDownloader = TestImageDownloader(result: .success)
+        imageDownloader: ImageDownloader = TestImageDownloader(result: .success),
+        networkMonitor: TestNetworkMonitor? = nil
     ) -> AvatarPickerViewModel {
         AvatarPickerViewModel(
             profile: .testProfile,
             authToken: "token",
             profileService: ProfileService(urlSession: session),
             avatarService: AvatarService(urlSession: session),
-            imageDownloader: imageDownloader
+            imageDownloader: imageDownloader,
+            networkMonitor: networkMonitor ?? TestNetworkMonitor()
         )
     }
 
@@ -208,6 +210,32 @@ final class AvatarPickerViewModelTests {
 
         let updatedAvatar = model.grid.avatars[0]
         #expect(updatedAvatar.altText == originalAltText, "Alt text should not have changed")
+    }
+
+    @Test("Test reload after connectivity reconnection")
+    func reloadAfterReconnection() async throws {
+        let networkMonitor = TestNetworkMonitor()
+        networkMonitor.isConnected = false
+        let session = URLSessionAvatarPickerMock(shouldSimulateNoNetworkConnection: true)
+
+        let model = Self.createModel(session: session, networkMonitor: networkMonitor)
+        await model.refresh()
+
+        #expect(model.gridResponseStatus?.error() != nil)
+
+        try await confirmation(expectedCount: 1) { @MainActor confirmation in
+            model.$gridResponseStatus.dropFirst().sink { result in
+                #expect(result?.error() == nil)
+                #expect(result?.value() != nil)
+
+                confirmation.confirm()
+            }.store(in: &cancellables)
+
+            session.shouldSimulateNoNetworkConnection = false
+            networkMonitor.isConnected = true
+            // Make the clock tick!
+            try await Task.sleep(for: .milliseconds(10))
+        }
     }
 }
 

--- a/GravatarAppTests/Helpers/TestNetworkMonitor.swift
+++ b/GravatarAppTests/Helpers/TestNetworkMonitor.swift
@@ -1,0 +1,8 @@
+import Combine
+@testable import GravatarApp
+
+class TestNetworkMonitor: NetworkMonitor {
+    var hasNetworkConnection: Published<Bool>.Publisher { $isConnected }
+
+    @Published var isConnected = true
+}

--- a/GravatarAppTests/Helpers/URLSessionAvatarPickerMock.swift
+++ b/GravatarAppTests/Helpers/URLSessionAvatarPickerMock.swift
@@ -2,10 +2,10 @@ import Foundation
 @testable import GravatarApp
 import GravatarUI
 
-final class URLSessionAvatarPickerMock: URLSessionProtocol {
+final class URLSessionAvatarPickerMock: URLSessionProtocol, @unchecked Sendable {
     static let internetLostErrorMessage: String = "The network connection was lost"
     let returnErrorCode: Int?
-    let shouldSimulateNoNetworkConnection: Bool
+    var shouldSimulateNoNetworkConnection: Bool
 
     init(returnErrorCode: Int? = nil, shouldSimulateNoNetworkConnection: Bool = false) {
         self.returnErrorCode = returnErrorCode


### PR DESCRIPTION
Closes GRA-432

This PR implements the basics of offline support:

- Persistent storage of the authenticated user profile.
- Network connectivity observer.

### Login logic:

- We search for an authenticated user's token in the keychain.
- We search for a Profile in storage
  - If there's a Profile
    - Go directly to authenticated section (tabs screen)
    - Fetch for the profile to update the stored data
    - Update the profile through UserSession which propagates the update
  - If there's no Profile
    - Show activity indicator while fetching for the Profile
    - Save the Profile in storage
    - Create the UserSession which is passed to the authenticated screens.

### Connectivity logic

- If the app starts without connectivity and a Profile is found in storage
  - Show the authenticated screens
  - The avatar grid will error since there's no connectivity to fetch them
  - The profile editor will display the latest known data
- When the connection is back:
  - Avatar list will reload automatically if an error is displayed
  - Profile fields and header will update to the last version, if there are changes coming from remote

### Future improvements

- Proper no-result display in avatar grid (possibly a "no internet connection" error message in the background)
- Block fields from being edited if there's no internet (maybe), because they will be overriden if there are changes coming from remote.
  - Alternatively, don't override the fields which have local changes.

To test:

- Test both logics described above.
- For connectivity, I recommend testing on device, as the network observer is not very reliable on the simulator.
- Test logout and login.
- Test switching accounts. 