### PR TITLE
Add readable content width constraint

### DIFF
--- a/GravatarApp/AvatarPicker/AvatarPickerView.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerView.swift
@@ -60,7 +60,6 @@ struct AvatarPickerView: View {
                         Spacer()
                     }
                 }
-                .readableContentWidth()
             } buttonMenuItems: {
                 MainMenuOptions(profile: avatarPickerModel.userSession.profile)
             } onRefresh: {

--- a/GravatarApp/AvatarPicker/AvatarPickerView.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerView.swift
@@ -60,6 +60,7 @@ struct AvatarPickerView: View {
                         Spacer()
                     }
                 }
+                .readableContentWidth()
             } buttonMenuItems: {
                 MainMenuOptions(profile: avatarPickerModel.userSession.profile)
             } onRefresh: {

--- a/GravatarApp/CommonViewModifiers/ReadableContentWidth.swift
+++ b/GravatarApp/CommonViewModifiers/ReadableContentWidth.swift
@@ -2,27 +2,27 @@ import SwiftUI
 import UIKit
 
 struct ReadableContentWidth: ViewModifier {
-  private let measureViewController = UIViewController()
+    private let measureViewController = UIViewController()
 
-  @State private var orientation: UIDeviceOrientation = UIDevice.current.orientation
+    @State private var orientation: UIDeviceOrientation = UIDevice.current.orientation
 
-  func body(content: Content) -> some View {
-    content
-      .frame(maxWidth: readableWidth(for: orientation))
-      .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
-        orientation = UIDevice.current.orientation
-      }
-  }
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: readableWidth(for: orientation))
+            .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+                orientation = UIDevice.current.orientation
+            }
+    }
 
-  private func readableWidth(for _: UIDeviceOrientation) -> CGFloat {
-    measureViewController.view.frame = UIScreen.main.bounds
-    let readableContentSize = measureViewController.view.readableContentGuide.layoutFrame.size
-    return readableContentSize.width
-  }
+    private func readableWidth(for _: UIDeviceOrientation) -> CGFloat {
+        measureViewController.view.frame = UIScreen.main.bounds
+        let readableContentSize = measureViewController.view.readableContentGuide.layoutFrame.size
+        return readableContentSize.width
+    }
 }
 
-public extension View {
-  func readableContentWidth() -> some View {
-    modifier(ReadableContentWidth())
-  }
+extension View {
+    public func readableContentWidth() -> some View {
+        modifier(ReadableContentWidth())
+    }
 }

--- a/GravatarApp/CommonViewModifiers/ReadableContentWidth.swift
+++ b/GravatarApp/CommonViewModifiers/ReadableContentWidth.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import UIKit
+
+struct ReadableContentWidth: ViewModifier {
+  private let measureViewController = UIViewController()
+
+  @State private var orientation: UIDeviceOrientation = UIDevice.current.orientation
+
+  func body(content: Content) -> some View {
+    content
+      .frame(maxWidth: readableWidth(for: orientation))
+      .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+        orientation = UIDevice.current.orientation
+      }
+  }
+
+  private func readableWidth(for _: UIDeviceOrientation) -> CGFloat {
+    measureViewController.view.frame = UIScreen.main.bounds
+    let readableContentSize = measureViewController.view.readableContentGuide.layoutFrame.size
+    return readableContentSize.width
+  }
+}
+
+public extension View {
+  func readableContentWidth() -> some View {
+    modifier(ReadableContentWidth())
+  }
+}

--- a/GravatarApp/ProfileEditor/ProfileEditorView.swift
+++ b/GravatarApp/ProfileEditor/ProfileEditorView.swift
@@ -31,6 +31,7 @@ struct ProfileEditorView: View {
             )
         } content: {
             ProfileEditContentView(viewModel: viewModel)
+                .readableContentWidth()
         } buttonMenuItems: {
             MainMenuOptions(profile: viewModel.userSession.profile)
         } onRefresh: {

--- a/GravatarApp/Share/ShareContentView.swift
+++ b/GravatarApp/Share/ShareContentView.swift
@@ -55,6 +55,7 @@ struct ShareContentView: View {
                         selected: viewModel.share.$contactForm
                     )
                 }
+                .readableContentWidth()
                 .padding()
                 Spacer()
             }


### PR DESCRIPTION
Closes GRA-553

## Description

Adds the readable content width constraint https://developer.apple.com/documentation/uikit/uiview/readablecontentguide 

Before:
<img width="1200" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2025-07-17 at 12 43 13" src="https://github.com/user-attachments/assets/f3dc7fe8-e72a-4a7e-97e3-1338c037431d" />

After:

<img width="1200" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2025-07-17 at 12 40 31" src="https://github.com/user-attachments/assets/43530774-0169-4ec0-b841-8df218680fbd" />

## To test

Check the profile and share tabs to see the constraint applies
Check with different kinds of devices to see if there's anything odd looking
