### PR TITLE
Avoid welcome screen flash on soft login

### DIFF
--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -72,6 +72,13 @@ class WelcomeViewModel: ObservableObject {
         }
     }
 
+    func softLoginConfiguration(profile: Profile, accessToken: String) {
+        userSession = .init(profile: profile, accessToken: accessToken, context: context)
+        Task {
+            await analytics.setUserName(profile.userLogin)
+        }
+    }
+
     func softLogin() {
         guard
             let currentUserHash = userDefaults.string(forKey: .Gravatar.currentUserKey),
@@ -81,7 +88,7 @@ class WelcomeViewModel: ObservableObject {
         let descriptor = FetchDescriptor<ProfileStore>(predicate: #Predicate { $0.userHash == currentUserHash })
 
         if let profile = try? context.fetch(descriptor).first?.profile {
-            configureSession(profile: profile, accessToken: accessToken)
+            softLoginConfiguration(profile: profile, accessToken: accessToken)
         }
 
         Task {


### PR DESCRIPTION
Closes GRA-560

After https://github.com/Automattic/Gravatar-iOS/pull/42, I noticed that the Welcome screen was flashing for a split second during the soft login (looking for the Profile in database).

This PR avoids this flash by removing animations when the Profile is found locally, and going directly to inside the app.

### To test:

- Run the app being logged in.
  - Check that there's no initial flashing of the welcome screen 