### PR TITLE
[Share screen] Share vcard action

### DIFF
--- a/GravatarApp/AppRoot/RootTabView.swift
+++ b/GravatarApp/AppRoot/RootTabView.swift
@@ -38,7 +38,7 @@ struct RootTabView: View {
 
                 // MARK: - Third tab
 
-                ShareTab(viewModel: shareViewModel)
+                ShareTab(viewModel: shareViewModel, avatarForceRefresh: $avatarPickerViewModel.forceRefreshAvatar)
             }
             // Needed to be added inside the TabView for the toast to follow the bottom safe area guide.
             .addToastContainer(manager: toastManager)
@@ -83,11 +83,15 @@ struct ProfileTab: View {
 
 struct ShareTab: View {
     @ObservedObject var viewModel: ShareViewModel
+    @Binding var avatarForceRefresh: Bool
 
     var body: some View {
         NavigationStack {
             BackgroundColorView(color: .secondarySystemBackground) {
-                ShareView(viewModel: viewModel)
+                ShareView(
+                    viewModel: viewModel,
+                    forceRefreshAvatar: $avatarForceRefresh
+                )
             }
         }
         .background(Color(uiColor: .secondarySystemBackground))

--- a/GravatarApp/AvatarPicker/AvatarPickerView.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerView.swift
@@ -10,10 +10,7 @@ struct AvatarPickerView: View {
     @State private var shareSheetItem: AvatarShareItem?
 
     var headerAvatarURL: URL? {
-        AvatarURL(
-            with: .hashID(avatarPickerModel.userSession.profile.hash),
-            options: .init(preferredSize: .pixels(256))
-        )?.url
+        AvatarURL.preferredURL(for: avatarPickerModel.userSession.profile.hash)
     }
 
     var body: some View {

--- a/GravatarApp/AvatarPicker/AvatarPickerView.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerView.swift
@@ -64,6 +64,7 @@ struct AvatarPickerView: View {
                 MainMenuOptions(profile: avatarPickerModel.userSession.profile)
             } onRefresh: {
                 await avatarPickerModel.refresh()
+                avatarPickerModel.forceRefreshAvatar = true
             }
         }
         .avatarDeletionDialog(avatar: $avatarToDelete, deleteAction: { avatar in

--- a/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
@@ -116,7 +116,6 @@ class AvatarPickerViewModel: ObservableObject {
 
         avatarSelectionTask = Task {
             let result = await postAvatarSelection(with: id, identifier: .hashID(userSession.profile.hash))
-            NotificationCenter.default.post(name: .avatarChanged, object: nil)
             return result
         }
 

--- a/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
@@ -22,6 +22,8 @@ class AvatarPickerViewModel: ObservableObject {
     }
 
     private var networkMonitor: any NetworkMonitor
+    private let notificationCenter: NotificationCenter
+
     let userSession: UserSession
 
     @Published var selectedAvatarURL: URL?
@@ -44,7 +46,8 @@ class AvatarPickerViewModel: ObservableObject {
         imageDownloader: ImageDownloader? = nil,
         networkMonitor: any NetworkMonitor = SystemNetworkMonitor.shared,
         urlSession: URLSessionProtocol = GravatarURLSession.shared,
-        toastManager: ToastManager = ToastManager()
+        toastManager: ToastManager = ToastManager(),
+        notificationCenter: NotificationCenter = .default
     ) {
         self.userSession = userSession
         self.profileService = profileService ?? Gravatar.ProfileService(urlSession: urlSession)
@@ -53,6 +56,7 @@ class AvatarPickerViewModel: ObservableObject {
         self.networkMonitor = networkMonitor
         self.profileHash = userSession.profile.hash
         self.toastManager = toastManager
+        self.notificationCenter = notificationCenter
 
         setupCombine()
     }
@@ -111,7 +115,9 @@ class AvatarPickerViewModel: ObservableObject {
         avatarSelectionTask?.cancel()
 
         avatarSelectionTask = Task {
-            await postAvatarSelection(with: id, identifier: .hashID(userSession.profile.hash))
+            let result = await postAvatarSelection(with: id, identifier: .hashID(userSession.profile.hash))
+            NotificationCenter.default.post(name: .avatarChanged, object: nil)
+            return result
         }
 
         return await avatarSelectionTask?.value

--- a/GravatarApp/Extensions/AvatarURL+Extensions.swift
+++ b/GravatarApp/Extensions/AvatarURL+Extensions.swift
@@ -1,0 +1,14 @@
+import Gravatar
+import Foundation
+
+extension ImageSize {
+    static var preferredSize: ImageSize {
+        .pixels(256)
+    }
+}
+
+extension AvatarURL {
+    static func preferredURL(for hash: String) -> URL? {
+        AvatarURL(with: .hashID(hash), options: .init(preferredSize: .preferredSize))?.url
+    }
+}

--- a/GravatarApp/Extensions/AvatarURL+Extensions.swift
+++ b/GravatarApp/Extensions/AvatarURL+Extensions.swift
@@ -1,5 +1,5 @@
-import Gravatar
 import Foundation
+import Gravatar
 
 extension ImageSize {
     static var preferredSize: ImageSize {

--- a/GravatarApp/Extensions/Notification+Extensios.swift
+++ b/GravatarApp/Extensions/Notification+Extensios.swift
@@ -4,4 +4,5 @@ extension Notification.Name {
     static let sessionExpired = Notification.Name("SessionExpiredNotification")
     static let showToast = Notification.Name("ShowToastNotification")
     static let signOut = Notification.Name("SignOutNotification")
+    static let avatarChanged = Notification.Name("AvatarChangedNotification")
 }

--- a/GravatarApp/Extensions/Notification+Extensios.swift
+++ b/GravatarApp/Extensions/Notification+Extensios.swift
@@ -4,5 +4,4 @@ extension Notification.Name {
     static let sessionExpired = Notification.Name("SessionExpiredNotification")
     static let showToast = Notification.Name("ShowToastNotification")
     static let signOut = Notification.Name("SignOutNotification")
-    static let avatarChanged = Notification.Name("AvatarChangedNotification")
 }

--- a/GravatarApp/ProfileEditor/ProfileEditorView.swift
+++ b/GravatarApp/ProfileEditor/ProfileEditorView.swift
@@ -36,6 +36,7 @@ struct ProfileEditorView: View {
             MainMenuOptions(profile: viewModel.userSession.profile)
         } onRefresh: {
             await viewModel.fetchProfile()
+            forceRefresh = true
         }
         .safeAreaInset(edge: .bottom, alignment: .center, spacing: nil) {
             Group {

--- a/GravatarApp/ProfileEditor/ProfileEditorView.swift
+++ b/GravatarApp/ProfileEditor/ProfileEditorView.swift
@@ -7,10 +7,7 @@ struct ProfileEditorView: View {
     @ObservedObject var viewModel: EditProfileViewModel
 
     var headerAvatarURL: URL? {
-        AvatarURL(
-            with: .hashID(viewModel.userSession.profile.hash),
-            options: .init(preferredSize: .pixels(256))
-        )?.url
+        AvatarURL.preferredURL(for: viewModel.userSession.profile.hash)
     }
 
     var body: some View {

--- a/GravatarApp/Share/QRCode/VCardGenerator.swift
+++ b/GravatarApp/Share/QRCode/VCardGenerator.swift
@@ -11,6 +11,9 @@ struct VCardModel {
     let phoneNumber: String
     let email: String
     let profileURL: String
+    let description: String
+    let avatarData: Data?
+}
 
     func generateVCard() -> String {
         vCard(self)
@@ -20,7 +23,7 @@ struct VCardModel {
 private func vCard(_ model: VCardModel) -> String {
     """
     BEGIN:VCARD
-    VERSION:4.0
+    VERSION:3.0
     PRODID:Gravatar iOS
     N:\(model.lastName);\(model.firstName);
     FN:\(model.displayName)
@@ -30,6 +33,8 @@ private func vCard(_ model: VCardModel) -> String {
     TEL:\(model.phoneNumber)
     EMAIL:\(model.email)
     URL:\(model.profileURL)
+    NOTE:\(model.description)
+    PHOTO;ENCODING=b;TYPE=JPEG:\(model.avatarData?.base64EncodedString() ?? "")
     END:VCARD
     """
 }

--- a/GravatarApp/Share/QRCode/VCardGenerator.swift
+++ b/GravatarApp/Share/QRCode/VCardGenerator.swift
@@ -13,7 +13,6 @@ struct VCardModel {
     let profileURL: String
     let description: String
     let avatarData: Data?
-}
 
     func generateVCard() -> String {
         vCard(self)

--- a/GravatarApp/Share/ShareHeaderView.swift
+++ b/GravatarApp/Share/ShareHeaderView.swift
@@ -10,6 +10,8 @@ struct ShareHeaderView<QRImage: View>: View {
 
     @Environment(\.openURL) var openURL
 
+    let onShareButtonPressed: (() -> Void)?
+
     private var qrImage: () -> QRImage
 
     private let horizontalSectionSpacing: CGFloat = 22
@@ -35,12 +37,14 @@ struct ShareHeaderView<QRImage: View>: View {
         topPadding: CGFloat,
         imageURL: URL?,
         forceRefresh: Binding<Bool>,
+        onShareButtonPressed: (() -> Void)? = nil
     ) {
         self.profile = profile
         self.topPadding = topPadding
         self.imageURL = imageURL
         self._forceRefresh = forceRefresh
         self.qrImage = qrImage
+        self.onShareButtonPressed = onShareButtonPressed
     }
 
     var body: some View {
@@ -91,7 +95,9 @@ struct ShareHeaderView<QRImage: View>: View {
         // skip forced dark mode coming from parent view (Bouncy)
         .environment(\.colorScheme, UITraitCollection.current.userInterfaceStyle == .dark ? .dark : .light)
 
-        CircularButton {} image: {
+        CircularButton {
+            onShareButtonPressed?()
+        } image: {
             Image(.shareIcon)
         }
         CircularButton {} image: {

--- a/GravatarApp/Share/ShareView.swift
+++ b/GravatarApp/Share/ShareView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct ShareView: View {
     @ObservedObject var viewModel: ShareViewModel
 
-    @State var forceRefresh: Bool = false
+    @Binding var forceRefreshAvatar: Bool
 
     var headerAvatarURL: URL? {
         AvatarURL(
@@ -31,7 +31,7 @@ struct ShareView: View {
                     qrImage: { qrImage },
                     topPadding: geometry.safeAreaInsets.top,
                     imageURL: headerAvatarURL,
-                    forceRefresh: $forceRefresh,
+                    forceRefresh: $forceRefreshAvatar,
                     onShareButtonPressed: onShareButtonPressed
                 )
 
@@ -45,8 +45,10 @@ struct ShareView: View {
             ShareSheet(items: [url])
                 .presentationDetents([.medium, .large])
         }
-        .onAppear {
-            viewModel.loadUserAvatarIfNeeded()
+        .onChange(of: forceRefreshAvatar) { _, newValue in
+            if newValue {
+                viewModel.refreshUserAvatar()
+            }
         }
     }
 
@@ -70,7 +72,8 @@ extension URL: @retroactive Identifiable {
             profile: .testProfile,
             accessToken: "",
             context: .testContext
-        ))
+        )),
+        forceRefreshAvatar: .constant(false)
     )
 }
 #endif

--- a/GravatarApp/Share/ShareView.swift
+++ b/GravatarApp/Share/ShareView.swift
@@ -8,10 +8,7 @@ struct ShareView: View {
     @Binding var forceRefreshAvatar: Bool
 
     var headerAvatarURL: URL? {
-        AvatarURL(
-            with: .hashID(viewModel.profile.hash),
-            options: .init(preferredSize: .pixels(256))
-        )?.url
+        AvatarURL.preferredURL(for: viewModel.profile.hash)
     }
 
     @ViewBuilder

--- a/GravatarApp/Share/ShareView.swift
+++ b/GravatarApp/Share/ShareView.swift
@@ -31,7 +31,8 @@ struct ShareView: View {
                     qrImage: { qrImage },
                     topPadding: geometry.safeAreaInsets.top,
                     imageURL: headerAvatarURL,
-                    forceRefresh: $forceRefresh
+                    forceRefresh: $forceRefresh,
+                    onShareButtonPressed: onShareButtonPressed
                 )
 
                 ShareContentView(viewModel: viewModel)
@@ -40,6 +41,25 @@ struct ShareView: View {
             .scrollDismissesKeyboard(.interactively)
         }
         .quickLookPreview($viewModel.contactPreviewURL)
+        .sheet(item: $viewModel.shareVCardURL) { url in
+            ShareSheet(items: [url])
+                .presentationDetents([.medium, .large])
+        }
+        .onAppear {
+            viewModel.loadUserAvatarIfNeeded()
+        }
+    }
+
+    func onShareButtonPressed() {
+        Task {
+            await viewModel.shareVCard()
+        }
+    }
+}
+
+extension URL: @retroactive Identifiable {
+    public var id: String {
+        self.absoluteString
     }
 }
 

--- a/GravatarApp/Share/ShareViewModel.swift
+++ b/GravatarApp/Share/ShareViewModel.swift
@@ -12,10 +12,11 @@ class ShareViewModel: ObservableObject {
 
     private let userSession: UserSession
     private var cancellables = Set<AnyCancellable>()
-    private var avatarData: Data?
-    private var avatarDownloadTask: Task<Data?, Never>?
+    //   private var avatarData: Data?
+    //   private var avatarDownloadTask: Task<Data?, Never>?
     private let notificationCenter: NotificationCenter
     private let urlSession: any URLSessionProtocol
+    private let networkMonitor: NetworkMonitor
 
     let qrGenerator: QRGenerator
 
@@ -28,13 +29,15 @@ class ShareViewModel: ObservableObject {
     init(
         userSession: UserSession,
         notificationCenter: NotificationCenter = .default,
-        urlSession: URLSessionProtocol? = nil
+        urlSession: URLSessionProtocol? = nil,
+        networkMonitor: NetworkMonitor = SystemNetworkMonitor.shared
     ) {
         self.userSession = userSession
         self.profile = userSession.profile
         self.qrGenerator = QRGenerator()
         self.notificationCenter = notificationCenter
         self.urlSession = urlSession ?? GravatarURLSession.shared
+        self.networkMonitor = networkMonitor
 
         setupObservers()
 
@@ -43,12 +46,6 @@ class ShareViewModel: ObservableObject {
             // Pre-fetch the user avatar for fast response on share/preview actions.
             refreshUserAvatar()
         }
-
-        notificationCenter.publisher(for: .avatarChanged).receive(on: RunLoop.main)
-            .sink { [weak self] _ in
-                self?.refreshUserAvatar()
-            }
-            .store(in: &cancellables)
     }
 
     func setupObservers() {
@@ -62,6 +59,12 @@ class ShareViewModel: ObservableObject {
         $share.sink { [weak self] _ in
             Task {
                 await self?.generateVCardQR()
+            }
+        }.store(in: &cancellables)
+
+        networkMonitor.hasNetworkConnection.dropFirst().sink { [weak self] newValue in
+            if newValue {
+                self?.refreshUserAvatar()
             }
         }.store(in: &cancellables)
     }
@@ -97,22 +100,12 @@ class ShareViewModel: ObservableObject {
     }
 
     private func getVCardWithAvatarData() async -> String {
-        let data = await getAvatarData()
+        let data = await fetchAvatarData()
         let vCardModel = vcardModel(with: data)
         return vcardGenerator.generate(with: vCardModel)
     }
 
-    private func getAvatarData() async -> Data? {
-        if let avatarData {
-            return avatarData
-        }
-        if let avatarDownloadTask {
-            return await avatarDownloadTask.value
-        }
-        return await fetchAvatarData()
-    }
-
-    private func fetchAvatarData(retryCount: Int = 0) async -> Data? {
+    private func fetchAvatarData() async -> Data? {
         let service = AvatarService(urlSession: urlSession)
         do {
             let result = try await service.fetch(
@@ -121,26 +114,13 @@ class ShareViewModel: ObservableObject {
             )
             return result.image.jpegData(compressionQuality: 0.7)
         } catch {
-            if retryCount <= 20 {
-                try? await Task.sleep(for: .seconds(min(retryCount, 4)))
-                return await fetchAvatarData(retryCount: retryCount + 1)
-            }
             return nil
         }
     }
 
-    func loadUserAvatarIfNeeded() {
-        guard avatarData == nil else {
-            return
-        }
-        refreshUserAvatar()
-    }
-
     func refreshUserAvatar() {
-        avatarData = nil
-        avatarDownloadTask = Task {
-            let data = await fetchAvatarData()
-            return data
+        Task {
+            await fetchAvatarData()
         }
     }
 

--- a/GravatarApp/Share/ShareViewModel.swift
+++ b/GravatarApp/Share/ShareViewModel.swift
@@ -105,7 +105,7 @@ class ShareViewModel: ObservableObject {
         do {
             let result = try await service.fetch(
                 with: .hashID(profile.hash),
-                options: .init(preferredSize: .pixels(256))
+                options: .init(preferredSize: .preferredSize)
             )
             return result.image.jpegData(compressionQuality: 0.7)
         } catch {

--- a/GravatarApp/Share/ShareViewModel.swift
+++ b/GravatarApp/Share/ShareViewModel.swift
@@ -12,9 +12,6 @@ class ShareViewModel: ObservableObject {
 
     private let userSession: UserSession
     private var cancellables = Set<AnyCancellable>()
-    //   private var avatarData: Data?
-    //   private var avatarDownloadTask: Task<Data?, Never>?
-    private let notificationCenter: NotificationCenter
     private let urlSession: any URLSessionProtocol
     private let networkMonitor: NetworkMonitor
 
@@ -28,14 +25,12 @@ class ShareViewModel: ObservableObject {
 
     init(
         userSession: UserSession,
-        notificationCenter: NotificationCenter = .default,
         urlSession: URLSessionProtocol? = nil,
         networkMonitor: NetworkMonitor = SystemNetworkMonitor.shared
     ) {
         self.userSession = userSession
         self.profile = userSession.profile
         self.qrGenerator = QRGenerator()
-        self.notificationCenter = notificationCenter
         self.urlSession = urlSession ?? GravatarURLSession.shared
         self.networkMonitor = networkMonitor
 

--- a/GravatarApp/Share/ShareViewModel.swift
+++ b/GravatarApp/Share/ShareViewModel.swift
@@ -7,9 +7,16 @@ class ShareViewModel: ObservableObject {
     @Published var contactPreviewURL: URL?
     @Published var profile: Profile
     @Published var qrCodeImage: Image?
+    @Published var shareVCardURL: URL?
+    @Published var share: ShareFieldsSelectionStore = .init()
 
     private let userSession: UserSession
     private var cancellables = Set<AnyCancellable>()
+    private var avatarData: Data?
+    private var avatarDownloadTask: Task<Data?, Never>?
+    private let notificationCenter: NotificationCenter
+    private let urlSession: any URLSessionProtocol
+
     let qrGenerator: QRGenerator
 
     @AppStorage("storedUserEmail")
@@ -18,18 +25,30 @@ class ShareViewModel: ObservableObject {
     @AppStorage("storedPhoneNumber")
     var storedPhoneNumber: String = ""
 
-    @Published var share: ShareFieldsSelectionStore = .init()
-
-    init(userSession: UserSession) {
+    init(
+        userSession: UserSession,
+        notificationCenter: NotificationCenter = .default,
+        urlSession: URLSessionProtocol? = nil
+    ) {
         self.userSession = userSession
         self.profile = userSession.profile
         self.qrGenerator = QRGenerator()
+        self.notificationCenter = notificationCenter
+        self.urlSession = urlSession ?? GravatarURLSession.shared
 
         setupObservers()
 
         Task { @MainActor in
             await generateVCardQR()
+            // Pre-fetch the user avatar for fast response on share/preview actions.
+            refreshUserAvatar()
         }
+
+        notificationCenter.publisher(for: .avatarChanged).receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.refreshUserAvatar()
+            }
+            .store(in: &cancellables)
     }
 
     func setupObservers() {
@@ -56,14 +75,76 @@ class ShareViewModel: ObservableObject {
     }
 
     func previewVCard() {
-        let data = vcardModel.generateVCard().data(using: .utf8)!
-        let tempDirectory = FileManager.default.temporaryDirectory
-        let url = tempDirectory.appendingPathComponent("contact.vcf")
-        try! data.write(to: url)
-        contactPreviewURL = url
+        Task {
+            let data = await getVCardWithAvatarData()
+            let url = getURL(for: data)
+            Task { @MainActor in
+                contactPreviewURL = url
+            }
+        }
     }
 
-    var vcardModel: VCardModel {
+    func shareVCard() async {
+        let vCardString = await getVCardWithAvatarData()
+        shareVCardURL = getURL(for: vCardString)
+    }
+
+    private func getURL(for vCardString: String) -> URL? {
+        let tempDirectory = FileManager.default.temporaryDirectory
+        let url = tempDirectory.appendingPathComponent("\(profile.displayName).vcf")
+        try? vCardString.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func getVCardWithAvatarData() async -> String {
+        let data = await getAvatarData()
+        let vCardModel = vcardModel(with: data)
+        return vcardGenerator.generate(with: vCardModel)
+    }
+
+    private func getAvatarData() async -> Data? {
+        if let avatarData {
+            return avatarData
+        }
+        if let avatarDownloadTask {
+            return await avatarDownloadTask.value
+        }
+        return await fetchAvatarData()
+    }
+
+    private func fetchAvatarData(retryCount: Int = 0) async -> Data? {
+        let service = AvatarService(urlSession: urlSession)
+        do {
+            let result = try await service.fetch(
+                with: .hashID(profile.hash),
+                options: .init(preferredSize: .pixels(256))
+            )
+            return result.image.jpegData(compressionQuality: 0.7)
+        } catch {
+            if retryCount <= 20 {
+                try? await Task.sleep(for: .seconds(min(retryCount, 4)))
+                return await fetchAvatarData(retryCount: retryCount + 1)
+            }
+            return nil
+        }
+    }
+
+    func loadUserAvatarIfNeeded() {
+        guard avatarData == nil else {
+            return
+        }
+        refreshUserAvatar()
+    }
+
+    func refreshUserAvatar() {
+        avatarData = nil
+        avatarDownloadTask = Task {
+            let data = await fetchAvatarData()
+            return data
+        }
+    }
+
+    func vcardModel(with avatarData: Data? = nil) -> VCardModel {
         VCardModel(
             firstName: share.name ? profile.firstName ?? "" : "",
             lastName: share.name ? profile.lastName ?? "" : "",
@@ -73,7 +154,9 @@ class ShareViewModel: ObservableObject {
             jobTitle: share.jobTitle ? profile.jobTitle : "",
             phoneNumber: share.phone ? storedPhoneNumber : "",
             email: share.email ? storedUserEmail : "",
-            profileURL: share.profileURL ? profile.profileUrl : ""
+            profileURL: share.profileURL ? profile.profileUrl : "",
+            description: share.description ? profile.description : "",
+            avatarData: avatarData
         )
     }
 }

--- a/GravatarApp/Share/ShareViewModel.swift
+++ b/GravatarApp/Share/ShareViewModel.swift
@@ -70,7 +70,7 @@ class ShareViewModel: ObservableObject {
     }
 
     func generateVCardQR() async {
-        let vcardString = vcardModel.generateVCard()
+        let vcardString = vcardModel().generateVCard()
         let qrImage = await qrGenerator.generateQRCode(from: vcardString)
         withAnimation {
             qrCodeImage = qrImage
@@ -102,7 +102,7 @@ class ShareViewModel: ObservableObject {
     private func getVCardWithAvatarData() async -> String {
         let data = await fetchAvatarData()
         let vCardModel = vcardModel(with: data)
-        return vcardGenerator.generate(with: vCardModel)
+        return vCardModel.generateVCard()
     }
 
     private func fetchAvatarData() async -> Data? {

--- a/GravatarAppTests/ShareScreenTests/ShareViewTests.swift
+++ b/GravatarAppTests/ShareScreenTests/ShareViewTests.swift
@@ -44,8 +44,15 @@ struct ShareViewTests {
 
     @Test("Snapshot of share view when the profile is empty")
     func shareViewEmpty() async throws {
-        let view = ShareView(viewModel: .init(userSession: .init(profile: .clean, accessToken: "", context: .testContext)))
-            .fullScreenFrame()
+        let view = ShareView(
+            viewModel: ShareViewModel(userSession: UserSession(
+                profile: .clean,
+                accessToken: "",
+                context: .testContext
+            )),
+            forceRefreshAvatar: .constant(false)
+        )
+        .fullScreenFrame()
 
         assertSnapshots(
             of: view,

--- a/GravatarAppTests/ShareScreenTests/ShareViewTests.swift
+++ b/GravatarAppTests/ShareScreenTests/ShareViewTests.swift
@@ -30,7 +30,7 @@ struct ShareViewTests {
 
     @Test
     func shareView() async throws {
-        let view = ShareView(viewModel: .init(userSession: .init(profile: .full, accessToken: "", context: .testContext)))
+        let view = ShareView(viewModel: .init(userSession: .init(profile: .full, accessToken: "", context: .testContext)), forceRefreshAvatar: .constant(false))
             .fullScreenFrame()
 
         assertSnapshots(


### PR DESCRIPTION
Closes GRA-574

This PR implements sharing the contact vCard through system share sheet. It includes the user's avatar.

I've implemented a pre-loading of the avatar when the app launches, and every-time the user selects a different avatar.
This has an automatic re-try mechanism in case of failure, and a backup reload-if-needed when the view opens.

https://github.com/user-attachments/assets/74f3adaf-305d-49fd-b689-58bd094b2676

### To test:

- Try the share action button on the Share screen header menu.
  - Check that the avatar is properly added to any destination where the vcard is opened. 
