### PR TITLE
Fix the QR size in iOS 18.2

### DIFF
--- a/GravatarApp/Share/ShareView.swift
+++ b/GravatarApp/Share/ShareView.swift
@@ -7,6 +7,7 @@ struct ShareView: View {
 
     @Binding var forceRefreshAvatar: Bool
     @State var scrollOffset: CGFloat = 0
+    @State var windowWidth: CGFloat = 0
     @State var safeAreaInsets: EdgeInsets = .init()
 
     var headerAvatarURL: URL? {
@@ -40,15 +41,21 @@ struct ShareView: View {
                     topPadding: topPadding,
                     imageURL: headerAvatarURL,
                     forceRefresh: $forceRefreshAvatar,
+                    windowWidth: $windowWidth,
                     onShareButtonPressed: onShareButtonPressed
                 )
-//                Text("topPadding: \(safeAreaInsets.top)")
                 ShareContentView(viewModel: viewModel)
             }
             .ignoresSafeArea(.container, edges: [.horizontal])
             .scrollDismissesKeyboard(.interactively)
             .onChange(of: geometry.safeAreaInsets) { _, newValue in
                 safeAreaInsets = newValue
+            }
+            .onChange(of: geometry.size) { _, value in
+                windowWidth = value.width
+            }
+            .onAppear {
+                windowWidth = geometry.size.width
             }
         }
         .quickLookPreview($viewModel.contactPreviewURL)

--- a/GravatarApp/Share/ShareViews/ShareHeaderView.swift
+++ b/GravatarApp/Share/ShareViews/ShareHeaderView.swift
@@ -75,9 +75,6 @@ struct ShareHeaderView<QRImage: View>: View {
             windowWidth: windowWidth,
             qrImage: qrImage
         )
-        .onChange(of: windowWidth) { _, newValue in
-            print("windowWidth: \(newValue)")
-        }
     }
 
     @ViewBuilder

--- a/GravatarApp/Share/ShareViews/ShareHeaderView.swift
+++ b/GravatarApp/Share/ShareViews/ShareHeaderView.swift
@@ -166,7 +166,7 @@ extension View {
                     16 : geo.safeAreaInsets.top,
                 imageURL: imageURL,
                 forceRefresh: .constant(false),
-                windowWidth: .constant(320)
+                windowWidth: .constant(geo.size.width)
             )
         }.ignoresSafeArea()
     }

--- a/GravatarApp/Share/ShareViews/ShareHeaderView.swift
+++ b/GravatarApp/Share/ShareViews/ShareHeaderView.swift
@@ -17,7 +17,7 @@ struct ShareHeaderView<QRImage: View>: View {
     private let horizontalSectionSpacing: CGFloat = 22
 
     @State private var buttonsSectionWidth: CGFloat = 0
-    @State private var windowWidth: CGFloat = 0
+    @Binding private var windowWidth: CGFloat
     @State private var presentFullScreen: Bool = false
 
     var qrWidth: CGFloat {
@@ -37,12 +37,14 @@ struct ShareHeaderView<QRImage: View>: View {
         topPadding: CGFloat,
         imageURL: URL?,
         forceRefresh: Binding<Bool>,
+        windowWidth: Binding<CGFloat>,
         onShareButtonPressed: (() -> Void)? = nil
     ) {
         self.profile = profile
         self.topPadding = topPadding
         self.imageURL = imageURL
         self._forceRefresh = forceRefresh
+        self._windowWidth = windowWidth
         self.qrImage = qrImage
         self.onShareButtonPressed = onShareButtonPressed
     }
@@ -65,7 +67,6 @@ struct ShareHeaderView<QRImage: View>: View {
             }
             .padding(.horizontal, .Global.contentHorizontalPadding)
         }
-        .contentWidthtReader($windowWidth)
         .presentQRCodeFullScreen(
             presentFullScreen: $presentFullScreen,
             topPadding: topPadding,
@@ -74,6 +75,9 @@ struct ShareHeaderView<QRImage: View>: View {
             windowWidth: windowWidth,
             qrImage: qrImage
         )
+        .onChange(of: windowWidth) { _, newValue in
+            print("windowWidth: \(newValue)")
+        }
     }
 
     @ViewBuilder
@@ -164,7 +168,8 @@ extension View {
                 geo.safeAreaInsets.top == 0 ?
                     16 : geo.safeAreaInsets.top,
                 imageURL: imageURL,
-                forceRefresh: .constant(false)
+                forceRefresh: .constant(false),
+                windowWidth: .constant(320)
             )
         }.ignoresSafeArea()
     }

--- a/GravatarAppTests/ShareScreenTests/ShareHeaderViewTests.swift
+++ b/GravatarAppTests/ShareScreenTests/ShareHeaderViewTests.swift
@@ -9,14 +9,15 @@ struct ShareHeaderViewTests {
     @Test
     func shareHeaderView() async throws {
         let imageURL = URL(string: "https://1.gravatar.com/avatar/1?size=256")
-
+        let width = ViewImageConfig.iPhone13.size?.width ?? 0
         let view = ScrollView {
             ShareHeaderView(
                 profile: .testProfile,
                 qrImage: { Image(systemName: "qrcode").resizable().foregroundStyle(.black).padding().background(Color.white) },
                 topPadding: 16,
                 imageURL: imageURL,
-                forceRefresh: .constant(false)
+                forceRefresh: .constant(false),
+                windowWidth: .constant(width)
             )
         }
         .fullScreenFrame()


### PR DESCRIPTION
The QR looks off in iOS 18.2.

<img width="320" alt="simulator_screenshot_A85C6CE3-3AD7-47A6-8467-8B5516A727A2" src="https://github.com/user-attachments/assets/0745dffe-0355-4a58-8e1c-5435ee06230d" />


This is because, to be able to calculate the windowWidth we need the QR component, but the QR component’s width also depends on windowWidth.

This PR calculates the window width on the parent level as a fix.