### PR TITLE
Avoid sending tracks events to remote

### DIFF
--- a/GravatarApp/AppRoot/GravatarAppApp.swift
+++ b/GravatarApp/AppRoot/GravatarAppApp.swift
@@ -1,7 +1,7 @@
+import Analytics
 import OAuth
 import SwiftData
 import SwiftUI
-import Analytics
 
 @main
 struct GravatarAppApp: App {

--- a/GravatarApp/AppRoot/GravatarAppApp.swift
+++ b/GravatarApp/AppRoot/GravatarAppApp.swift
@@ -1,6 +1,7 @@
 import OAuth
 import SwiftData
 import SwiftUI
+import Analytics
 
 @main
 struct GravatarAppApp: App {
@@ -9,6 +10,7 @@ struct GravatarAppApp: App {
     @StateObject private var welcomeViewModel: WelcomeViewModel
 
     init() {
+        Analytics.setPushEventsToRemote(false)
         do {
             let context = try ModelContext(ModelContainer(for: ProfileStore.self))
             self.modelContext = context

--- a/Packages/Analytics/Sources/Analytics/Analytics.swift
+++ b/Packages/Analytics/Sources/Analytics/Analytics.swift
@@ -5,6 +5,7 @@ import OSLog
 
 public actor Analytics {
     public static let shared = Analytics()
+    private static var pushEventsToRemote: Bool = true
 
     private let tracker: Tracker
     private let logger = Logger(subsystem: "com.gravatar", category: "gravatar.analytics")
@@ -28,10 +29,13 @@ public actor Analytics {
     func track(_ event: AnalyticsEvent) {
         let properties = event.jsonProperties ?? [:]
 
-        tracker.track(event.name, withCustomProperties: properties)
+        if Self.pushEventsToRemote {
+            tracker.track(event.name, withCustomProperties: properties)
+        }
 
         #if DEBUG
-        logger.debug("🔹 Tracking: \(event.name); properties: \(properties)")
+        let trackingText = !Self.pushEventsToRemote ? " (Locally)" : ""
+        logger.debug("🔹 Tracking\(trackingText): \(event.name); properties: \(properties)")
         #endif
     }
 
@@ -40,6 +44,10 @@ public actor Analytics {
         tracker.setUserName(userName, userUUIDStorage: userUUIDStorage)
 
         updateUserProperties()
+    }
+
+    public static func setPushEventsToRemote(_ pushEventsToRemote: Bool) {
+        Self.pushEventsToRemote = pushEventsToRemote
     }
 
     private var defaultProperties: [String: AnyHashable] {


### PR DESCRIPTION
Closes GRA-608

This PR adds a property to Analytics which allows to control if the track events will be send to remote.
For now, we set it to avoid events being tracked remotely.

Note: To see the Tracks log, you need to enable back `OS_ACTIVITY_MODE` on the schema Run arguments.

### To test:
- Activate `OS_ACTIVITY_MODE`
- Go throw the login flow.
- Send the app to the background
  -  Check that there are no logs from Tracks which send events to remote
  - You can double-check using Proxyman or similar software.
  - You can triple-check going to Tracks site to verify that there are no new track events from the app.