### PR TITLE
[Tooling] Add automation to generate strings from source

### DIFF
--- a/GravatarApp/Resources/en.lproj/Localizable.strings
+++ b/GravatarApp/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,270 @@
+/* Text for the 'Done' button in the 'About Gravatar' view */
+"AboutModal.CloseButton.title" = "Done";
+
+/* Title for the 'Get help' section in the 'About Gravatar' view */
+"AboutModal.getHelpTitle" = "Get help";
+
+/* Title for the 'Legal' section in the 'About Gravatar' view */
+"AboutModal.legalTitle" = "Legal";
+
+/* Link text for the 'Privacy Policy' in the 'About Gravatar' view */
+"AboutModal.privacyPolicyText" = "Privacy Policy";
+
+/* Link text for the 'Terms of Service' in the 'About Gravatar' view */
+"AboutModal.termsOfServiceText" = "Terms of Service";
+
+/* Title for the 'About Gravatar' view */
+"AboutModal.title" = "About Gravatar";
+
+/* Accessibility label spoken outloud by VoiceOver when an avatar is selected. The '%@' is the Alt text of the avatar image. */
+"Avatar.Accessibility.AvatarButton.Label" = "Avatar Image. %@";
+
+/* An option in the avatar menu that edits the avatar's Alt Text. */
+"AvatarPicker.AvatarAction.altText" = "Alt Text";
+
+/* An option in the avatar menu that deletes the avatar */
+"AvatarPicker.AvatarAction.delete" = "Delete";
+
+/* An option in the avatar menu that selects the avatar */
+"AvatarPicker.AvatarAction.select" = "Select";
+
+/* An option in the avatar menu that shares the avatar */
+"AvatarPicker.AvatarAction.share" = "Share...";
+
+/* The title of the retry button shown when avatars cannot be loaded. */
+"AvatarPicker.Avatars.Loading.Error.buttonTitle" = "Retry";
+
+/* The description of the error shown when avatars cannot be loaded. */
+"AvatarPicker.Avatars.Loading.Error.description" = "There was an issue loading your avatars. Please try again in a few minutes.";
+
+/* The title of the error shown when avatars cannot be loaded. */
+"AvatarPicker.Avatars.Loading.Error.title" = "Unable to load avatars";
+
+/* The title button which confirms the avatar deletion. */
+"AvatarPicker.Deletion.Confirmation.ctaButtonTitle" = "Delete";
+
+/* Title of the confirmation dialog to delete an avatar */
+"AvatarPicker.Deletion.Confirmation.title" = "Are you sure you want to delete this image?";
+
+/* The title of the dismiss button on a confirmation dialog. */
+"AvatarPicker.Dismiss.title" = "Dismiss";
+
+/* A label displayed above an empty avatars grid. */
+"AvatarPicker.Grid.Empty.label" = "Your avatars will show up here.";
+
+/* A warning message that appears above the avatars grid when there's no selected avatar. */
+"AvatarPicker.Grid.NoSelectedAvatar" = "No avatar selected. Showing the default avatar.";
+
+/* A subtext that appears below the avatars grid title */
+"AvatarPicker.Grid.subtext" = "Tap for options.";
+
+/* Title of the avatars grid */
+"AvatarPicker.Grid.title" = "Previous avatars";
+
+/* Error message to show when the upload fails because the image is too big. */
+"AvatarPicker.Upload.Error.ImageTooBig.Error" = "The provided image exceeds the maximum size: 10MB";
+
+/* The title of the remove button on the upload error dialog. */
+"AvatarPicker.Upload.Error.Remove.title" = "Remove";
+
+/* The title of the retry button on the upload error dialog. */
+"AvatarPicker.Upload.Error.Retry.title" = "Retry";
+
+/* The title of the upload error dialog. */
+"AvatarPicker.Upload.Error.title" = "Upload has failed";
+
+/* Title for the section with the upload image buttons */
+"AvatarPicker.UploadSection.header" = "Get a new look";
+
+/* Subtitle for the section with the upload image buttons */
+"AvatarPicker.UploadSection.subtitle" = "Let your personality shine with a new avatar.";
+
+/* This error message shows when the user attempts to change the alt text of an avatar and fails. */
+"AvatarPickerViewModel.AltText.Error" = "Oops, something didn't quite work out while trying to update the alt text.";
+
+/* This confirmation message shows when the user has updated the alt text. */
+"AvatarPickerViewModel.AltText.Success" = "Image alt text was changed successfully.";
+
+/* This error message shows when the avatars request fails. */
+"AvatarPickerViewModel.AvatarsRequest.Error" = "Unable to get your avatars. Try again.";
+
+/* This error message shows when the user attempts to delete an avatar and fails. */
+"AvatarPickerViewModel.Delete.Error" = "Couldn't delete the image. Try again.";
+
+/* This error message shows when the user attempts to share an avatar and fails. */
+"AvatarPickerViewModel.Share.Fail" = "Couldn't share your avatar. Try again.";
+
+/* This error message shows when the user attempts to pick a different avatar and fails. */
+"AvatarPickerViewModel.Update.Fail" = "Unable to change your avatar. Try again.";
+
+/* This confirmation message shows when the user picks a different avatar. */
+"AvatarPickerViewModel.Update.Success" = "Avatar updated.";
+
+/* A generic error message to show on an error dialog when the upload fails. */
+"AvatarPickerViewModel.Upload.Error.message" = "Oops, there was an error uploading the image.";
+
+/* Screen title. Resize and crop an image. */
+"ImageCropper.title" = "Resize & Crop";
+
+/* Title for the button to show 'about this app' section */
+"MainMenu.Option.about" = "About this app";
+
+/* Title for the button to share the user's profile */
+"MainMenu.Option.share" = "Share";
+
+/* Title for the button to sign out */
+"MainMenu.Option.signOut" = "Sign out";
+
+/* Title for the button to visit the user's profile */
+"MainMenu.Option.visitProfile" = "Visit your profile";
+
+/* Label of a field that contains a short biography or description about the user. */
+"Profile.AboutInfoField.aboutMe" = "About Me";
+
+/* Description for the 'About me' field in the profile editing screen. */
+"Profile.AboutInfoField.aboutMe.footer" = "Brief description for your profile.";
+
+/* Label of a field that contains the company or organization the user is affiliated with. */
+"Profile.AboutInfoField.company" = "Company";
+
+/* Label of a field that contains a user’s email. */
+"Profile.AboutInfoField.contactEmail" = "Email";
+
+/* Label of a field that contains a user’s phone number. */
+"Profile.AboutInfoField.contactPhone" = "Phone";
+
+/* Label of a field that contains a user’s display name. */
+"Profile.AboutInfoField.displayName" = "Display Name";
+
+/* Label of a field that contains a user’s first name. */
+"Profile.AboutInfoField.firstName" = "First Name";
+
+/* Label of a field that contains the user's current job title or role. */
+"Profile.AboutInfoField.jobTitle" = "Job Title";
+
+/* Label of a field that contains a user’s last name. */
+"Profile.AboutInfoField.lastName" = "Last Name";
+
+/* Label of a field that contains the user's geographic location. */
+"Profile.AboutInfoField.location" = "Location";
+
+/* Label of a field that contains the pronouns the user identifies with (e.g., she/her, they/them). */
+"Profile.AboutInfoField.pronouns" = "Pronouns";
+
+/* Label of a field that contains a phonetic pronunciation of the user’s name. */
+"Profile.AboutInfoField.pronunciation" = "Pronunciation";
+
+/* Description for the 'Pronunciation' field in the profile editing screen. */
+"Profile.AboutInfoField.pronunciation.footer" = "Let them know how your name sounds like.";
+
+/* Title of the cancel button in the profile editing screen. */
+"Profile.CancelButton.title" = "Cancel";
+
+/* Default message shown when there is an error saving the profile. */
+"Profile.Refresh.errorMessage" = "Unable to refresh your profile. Try again.";
+
+/* Default message shown when there is an error saving the profile. */
+"Profile.Save.errorMessage" = "Unable to save your profile. Try again.";
+
+/* Message shown when the profile is saved successfully. */
+"Profile.Save.successMessage" = "Profile saved.";
+
+/* Title of the save button in the profile editing screen. */
+"Profile.SaveButton.title" = "Save";
+
+/* Text shown while saving changes in the profile editing screen. */
+"Profile.Saving.text" = "Saving...";
+
+/* Title of the about section in the profile editing screen. */
+"Profile.Section.About.header" = "About";
+
+/* Title of the contact info section in the profile editing screen. */
+"Profile.Section.Contact.header" = "Contact";
+
+/* Title of the name section in the profile editing screen. */
+"Profile.Section.Name.header" = "Name";
+
+/* Title of the professional/work info section in the profile editing screen. */
+"Profile.Section.Professional.header" = "Professional";
+
+/* Title for the account url field. %@ is the service label. e.g. 'WordPress account'. */
+"Share.Contact.Account.title" = "%@ account";
+
+/* Title for the email field to be shared via QR code */
+"Share.Contact.Email.title" = "Email";
+
+/* Title for the section with the public Gravatar contact info. */
+"Share.Contact.GravatarFieldsSection.title" = "Share info from your Gravatar profile.";
+
+/* Title for the name field to be shared via QR code */
+"Share.Contact.Name.title" = "Name";
+
+/* Title for the phone number field to be shared via QR code */
+"Share.Contact.PhoneNumber.title" = "Phone number";
+
+/* Title for the preview vCard button. */
+"Share.Contact.Preview.Button.title" = "Preview";
+
+/* Title for the preview section. */
+"Share.Contact.Preview.title" = "See what others will see when they scan your QR code.";
+
+/* Title for the section with the private contact info. */
+"Share.Contact.PrivateSection.title" = "Share private contact info.";
+
+/* Title for the profile url field to be shared via QR code */
+"Share.Contact.ProfileURL.title" = "Profile URL";
+
+/* Message shown when there is no data to show in a share field */
+"Share.Field.noData" = "No data";
+
+/* Message explaining what is the QR code for. */
+"Share.Header.explanation" = "Let others scan this QR code to share your contact information.";
+
+/* Button title to dismiss the private information alert */
+"Share.PrivateInfoAlert.DismissButton.title" = "Got it";
+
+/* Message explanation about sharing private information */
+"Share.PrivateInfoAlert.message" = "Your email and phone number are only shared using the QR code. This information is not saved to your Gravatar profile, and is not publicly available.";
+
+/* Title of the explaining alert about sharing private information */
+"Share.PrivateInfoAlert.title" = "Private information";
+
+/* An option in a menu that will display the camera for taking a picture */
+"SystemImagePickerView.Source.Camera.title" = "Camera";
+
+/* An option in a menu that display the user's Photo Library and allow them to choose a photo from it */
+"SystemImagePickerView.Source.PhotoLibrary.title" = "Photos";
+
+/* An option to show the image playground */
+"SystemImagePickerView.Source.Playground.title" = "Playground";
+
+/* Title for the profile tab */
+"Tabs.Profile.title" = "Profile";
+
+/* Title for the share tab */
+"Tabs.Share.title" = "Share";
+
+/* Message for the error when OAuth is denied by the user. */
+"Welcome.Error.OAuth.Denied.message" = "You need to log in to Gravatar.com.";
+
+/* Generic error message when OAuth fails. */
+"Welcome.Error.OAuth.Generic.message" = "Unable to request access.";
+
+/* Generic error message when the profile fetch fails for an unkonwn reason. */
+"Welcome.Error.Profile.Generic.message" = "There was an unknown issue loading your profile.";
+
+/* Title for the error when the profile fetch fails. */
+"Welcome.Error.Profile.title" = "Unable to load your profile.";
+
+/* Title for the button to login with another account. */
+"Welcome.Login.AnotherAccountButton.title" = "Try with another account";
+
+/* Title for the main login button. */
+"Welcome.Login.MainButton.title" = "Login";
+
+/* Title for the button to try again after a login failure. */
+"Welcome.Login.TryAgainButton.title" = "Try again";
+
+/* Subtitle for the login screen */
+"Welcome.Logo.subtitle" = "Your globally recognized avatar.";
+

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -136,6 +136,31 @@ platform :ios do
   lane :configure_code_signing_enterprise do |readonly: true|
     configure_code_signing(app_identifier: app_bundle_identifier_enterprise!, type: 'enterprise', team_id: enterprise_team_id!, readonly: readonly)
   end
+
+  # Generates the `.strings` files for the base language based on the app's source code.
+  #
+  lane :generate_strings do |skip_commit: false|
+    gravatar_app_path = File.join(PROJECT_ROOT_FOLDER, 'GravatarApp')
+    en_lproj_path = File.join(gravatar_app_path, 'Resources', 'en.lproj')
+
+    # Use release-toolkit which uses `genstrings` to generate strings
+    ios_generate_strings_file_from_code(
+      paths: [gravatar_app_path],
+      output_dir: en_lproj_path,
+      output_encoding: 'UTF-8',
+      routines: ['NSLocalizedString'],
+      quiet: false
+    )
+
+    next if skip_commit
+
+    git_add(path: en_lproj_path)
+    git_commit(
+      path: en_lproj_path,
+      message: 'Update strings in base locale',
+      allow_nothing_to_commit: true
+    )
+  end
 end
 
 def configure_code_signing(app_identifier:, type:, team_id:, readonly:)


### PR DESCRIPTION
Fixes AINFRA-1039

This PR adds a basic automation to generate strings based on the source code.
We can later plug this lane into more complex lanes and workflows (for example, during release management).
I've followed this approach also for better GlotPress compatibility.

I've also ran the lane so that the initial `en.lproj/Localizable.strings` is generated and I [imported](https://translate.wordpress.com/projects/gravatar/gravatar-ios/) it to GlotPress.
