### PR TITLE
Haptic feedback

### DIFF
--- a/GravatarApp/AppRoot/RootTabView.swift
+++ b/GravatarApp/AppRoot/RootTabView.swift
@@ -58,6 +58,12 @@ struct RootTabView: View {
             }
         }
         .modalPresentation(manager: modalManager)
+        .sensoryFeedback(.error, trigger:  toastManager.toasts) { _, toasts in
+            toasts.first { $0.type == .error } != nil
+        }
+        .sensoryFeedback(.success, trigger: toastManager.toasts) { _, toasts in
+            toasts.first { $0.type == .info } != nil
+        }
     }
 }
 

--- a/GravatarApp/AppRoot/RootTabView.swift
+++ b/GravatarApp/AppRoot/RootTabView.swift
@@ -58,7 +58,7 @@ struct RootTabView: View {
             }
         }
         .modalPresentation(manager: modalManager)
-        .sensoryFeedback(.error, trigger:  toastManager.toasts) { _, toasts in
+        .sensoryFeedback(.error, trigger: toastManager.toasts) { _, toasts in
             toasts.first { $0.type == .error } != nil
         }
         .sensoryFeedback(.success, trigger: toastManager.toasts) { _, toasts in

--- a/GravatarApp/AvatarPicker/AvatarPickerView.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerView.swift
@@ -70,6 +70,8 @@ struct AvatarPickerView: View {
             }
         })
         .avatarShareSheet(item: $shareSheetItem)
+        .sensoryFeedback(.error, trigger: avatarPickerModel.imageUploadErrorID)
+        .sensoryFeedback(.success, trigger: avatarPickerModel.imageUploadSuccessID)
     }
 
     func gridView() -> some View {

--- a/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
@@ -26,6 +26,9 @@ class AvatarPickerViewModel: ObservableObject {
 
     let userSession: UserSession
 
+    var imageUploadErrorID: UUID?
+    var imageUploadSuccessID: UUID?
+
     @Published var selectedAvatarURL: URL?
     @Published private(set) var backendSelectedAvatarURL: URL?
     @Published private(set) var gridResponseStatus: Result<Void, Error>?
@@ -303,6 +306,7 @@ class AvatarPickerViewModel: ObservableObject {
                 self.selectedAvatarURL = URL(string: avatar.imageURL)
                 self.backendSelectedAvatarURL = URL(string: avatar.imageURL)
             }
+            imageUploadSuccessID = UUID()
         } catch ImageUploadError.responseError(reason: let .invalidHTTPStatusCode(response, errorPayload))
             where response.statusCode == HTTPStatus.badRequest.rawValue || response.statusCode == HTTPStatus.payloadTooLarge.rawValue
         {
@@ -353,6 +357,7 @@ class AvatarPickerViewModel: ObservableObject {
             altText: storedModel?.altText ?? ""
         )
         grid.replaceModel(withID: imageID, with: newModel)
+        imageUploadErrorID = UUID()
     }
 
     private func handleUnrecoverableClientError(_ error: Error) {

--- a/GravatarApp/AvatarPicker/AvatarUpload/SystemImagePickerView.swift
+++ b/GravatarApp/AvatarPicker/AvatarUpload/SystemImagePickerView.swift
@@ -65,6 +65,9 @@ struct ImagePicker<Label>: View where Label: View {
                     })
             }
         )
+        .sensoryFeedback(.selection, trigger: presentPicker) { _, presentPicker in
+            presentPicker == true
+        }
     }
 
     func imageEditor(with item: ImagePickerItem) -> some View {


### PR DESCRIPTION
Closes GRA-637

This PR adds some basic haptic feedback to the main interactions:

- Success toast (success feedback)
  - We do have `info` instead of `success`. But so far we only use it as success message. 
  - This triggers on:
    - Avatar selection success 
    - Profile save changes success
- Error toast (error feedback)
  - This triggers on:
    - Avatar selection error 
    - Profile save changes error
- Upload image success (success feedback)
- Upload image error (error feedback)
- Image picker buttons tap (selection feedback)
  - I added these since the buttons have little to no visual feedback, and sometimes they can be slow to react

### To test:

- Run the app on a device
- Try the previously described scenarios
  - Check that the haptic feedback triggers as expected and it feels OK 