### PR TITLE
Remove avatar from QR preview

### DIFF
--- a/GravatarApp/Share/ShareViewModel.swift
+++ b/GravatarApp/Share/ShareViewModel.swift
@@ -88,7 +88,7 @@ class ShareViewModel: ObservableObject {
 
     func previewVCard() {
         Task {
-            let data = await getVCardWithAvatarData()
+            let data = await getVCard(withAvatarData: false)
             let url = getURL(for: data)
             Task { @MainActor in
                 contactPreviewURL = url
@@ -97,7 +97,7 @@ class ShareViewModel: ObservableObject {
     }
 
     func shareVCard() async {
-        let vCardString = await getVCardWithAvatarData()
+        let vCardString = await getVCard(withAvatarData: true)
         shareVCardURL = getURL(for: vCardString)
     }
 
@@ -108,8 +108,8 @@ class ShareViewModel: ObservableObject {
         return url
     }
 
-    private func getVCardWithAvatarData() async -> String {
-        let data = await fetchAvatarData()
+    private func getVCard(withAvatarData: Bool = true) async -> String {
+        let data = withAvatarData ? await fetchAvatarData() : nil
         let vCardModel = vcardModel(with: data)
         return vCardModel.generateVCard()
     }


### PR DESCRIPTION
Closes GRA-635

This PR removes the avatar from QR preview.

### To test:

- Run the app
- Go to Share screen
- Scroll to the end of the screen
- Tap on `Preview`
  - Check that the preview won't show the avatar
- Tap the Share button on the header
- On the share sheet, choose the Contacts app
  - Check that the contacts app preview shows the profile avatar.
    