### PR TITLE
Fix caching issue on avatars

### DIFF
--- a/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
@@ -65,7 +65,7 @@ class AvatarPickerViewModel: ObservableObject {
         notificationCenter: NotificationCenter = .default,
         userDefaults: UserDefaults = .standard
     ) {
-        self.urlSession = urlSession as? URLSession
+        self.urlSession = (urlSession as? GravatarURLSession)?.urlSession as? URLSession
         self.userSession = userSession
         self.profileService = profileService ?? Gravatar.ProfileService(urlSession: urlSession)
         self.avatarService = avatarService ?? AvatarService(urlSession: urlSession)

--- a/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
@@ -5,6 +5,7 @@ import SwiftUI
 
 @MainActor
 class AvatarPickerViewModel: ObservableObject {
+    private static let selectedAvatarURLKey = "selectedAvatarURLKey"
     private let profileService: Gravatar.ProfileService
     private let avatarService: AvatarService
     private let imageDownloader: ImageDownloader
@@ -25,11 +26,22 @@ class AvatarPickerViewModel: ObservableObject {
     private let notificationCenter: NotificationCenter
 
     let userSession: UserSession
+    private let urlSession: URLSession?
+    private let userDefaults: UserDefaults
 
     var imageUploadErrorID: UUID?
     var imageUploadSuccessID: UUID?
 
     @Published var selectedAvatarURL: URL?
+    private var savedSelectedAvatarURL: URL? {
+        set {
+            userDefaults.set(newValue, forKey: Self.selectedAvatarURLKey)
+        }
+        get {
+            userDefaults.url(forKey: Self.selectedAvatarURLKey)
+        }
+    }
+
     @Published private(set) var backendSelectedAvatarURL: URL?
     @Published private(set) var gridResponseStatus: Result<Void, Error>?
     @Published private(set) var grid: AvatarGridModel = .init(avatars: [])
@@ -50,8 +62,10 @@ class AvatarPickerViewModel: ObservableObject {
         networkMonitor: any NetworkMonitor = SystemNetworkMonitor.shared,
         urlSession: URLSessionProtocol = GravatarURLSession.shared,
         toastManager: ToastManager = ToastManager(),
-        notificationCenter: NotificationCenter = .default
+        notificationCenter: NotificationCenter = .default,
+        userDefaults: UserDefaults = .standard
     ) {
+        self.urlSession = urlSession as? URLSession
         self.userSession = userSession
         self.profileService = profileService ?? Gravatar.ProfileService(urlSession: urlSession)
         self.avatarService = avatarService ?? AvatarService(urlSession: urlSession)
@@ -60,6 +74,7 @@ class AvatarPickerViewModel: ObservableObject {
         self.profileHash = userSession.profile.hash
         self.toastManager = toastManager
         self.notificationCenter = notificationCenter
+        self.userDefaults = userDefaults
 
         setupCombine()
     }
@@ -93,10 +108,14 @@ class AvatarPickerViewModel: ObservableObject {
             .store(in: &cancellables)
 
         $selectedAvatarURL
-            .removeDuplicates()
-            .dropFirst(2) // First value is nil, second value is the first time we load the URL, no need to `forceRefresh` for these cases.
-            .sink { [weak self] _ in
-                self?.forceRefreshAvatar = true
+            .dropFirst(1) // First value is nil, no need to `forceRefresh` in that case.
+            .sink { [weak self] url in
+                guard let self else { return }
+                if self.savedSelectedAvatarURL != url {
+                    resetURLCache()
+                    self.forceRefreshAvatar = true
+                    self.savedSelectedAvatarURL = url
+                }
             }
             .store(in: &cancellables)
 
@@ -151,6 +170,12 @@ class AvatarPickerViewModel: ObservableObject {
         return nil
     }
 
+    private func resetURLCache() {
+        if let urlCache = urlSession?.configuration.urlCache {
+            urlCache.removeAllCachedResponses()
+        }
+    }
+
     func fetchAvatars() async {
         defer {
             withAnimation(.smooth) {
@@ -167,8 +192,8 @@ class AvatarPickerViewModel: ObservableObject {
             withAnimation(.smooth) {
                 grid.setAvatars(images.map(AvatarImageModel.init))
             }
+            selectedAvatarURL = grid.selectedAvatar?.url // always set the selectedAvatarURL even `nil`
             if let selectedAvatar = grid.selectedAvatar {
-                selectedAvatarURL = selectedAvatar.url
                 selectedAvatarResult = .success(selectedAvatar.id)
             }
             gridResponseStatus = .success(())

--- a/GravatarApp/CommonViews/HeaderAvatarView.swift
+++ b/GravatarApp/CommonViews/HeaderAvatarView.swift
@@ -8,19 +8,22 @@ struct HeaderAvatarView: View {
 
     let placeholderColor: Color
     let transaction: Transaction
+    let urlSession: URLSession
 
     init(
         imageURL: URL?,
         showLoading: Bool = false,
         forceRefresh: Binding<Bool>,
         placeholderColor: Color = .secondary,
-        animation: Animation? = nil
+        animation: Animation? = nil,
+        urlSession: URLSession = GravatarURLSession.shared.urlSession
     ) {
         self.imageURL = imageURL
         self.showLoading = showLoading
         self._forceRefresh = forceRefresh
         self.placeholderColor = placeholderColor
         self.transaction = Transaction(animation: animation)
+        self.urlSession = urlSession
     }
 
     var body: some View {
@@ -29,6 +32,7 @@ struct HeaderAvatarView: View {
             placeholderView: {
                 placeholderColor
             },
+            urlSession: urlSession,
             oneTimeForceRefresh: $forceRefresh,
             loadingView: {
                 showLoading ?

--- a/GravatarApp/Networking/GravatarURLSession.swift
+++ b/GravatarApp/Networking/GravatarURLSession.swift
@@ -4,7 +4,7 @@ import Gravatar
 /// Intercepts the network requests to perform common operations.
 final class GravatarURLSession: URLSessionProtocol, Sendable {
     static let shared = GravatarURLSession()
-    fileprivate let urlSession: URLSession
+    let urlSession: URLSession
 
     private init() {
         self.urlSession = URLSession(


### PR DESCRIPTION
Closes GRA-655

## Description

Fixes an issue where the previous avatar remains on the header. We start to persist the previous avatar URL and compare it with the newly selected avatar URL. If they are different we start to clear the URLCache because otherwise it will still serve the older image. 

## Test

1. Select a different avatar, or remove the existing avatar (Try both)
2. Kill and reopen the app
3. Observe the correct avatar is visible on the headers

Repeat the test by doing step 1 from a different device/client.
