### PR TITLE
Fix outdated avatar issue

### DIFF
--- a/GravatarApp/AppRoot/RootTabView.swift
+++ b/GravatarApp/AppRoot/RootTabView.swift
@@ -55,6 +55,7 @@ struct RootTabView: View {
         .onAppear {
             Task {
                 await avatarPickerViewModel.fetchAvatars()
+                avatarPickerViewModel.forceRefreshAvatar = true
             }
         }
         .modalPresentation(manager: modalManager)

--- a/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerViewModel.swift
@@ -94,7 +94,7 @@ class AvatarPickerViewModel: ObservableObject {
 
         $selectedAvatarURL
             .removeDuplicates()
-            .dropFirst(2) // First value is nil, second value is the first time we load the URL, no need to `forceRefresh` for these cases.
+            .dropFirst(1) // First value is nil, no need to `forceRefresh` in that case.
             .sink { [weak self] _ in
                 self?.forceRefreshAvatar = true
             }


### PR DESCRIPTION
Closes GRA-655

## Description

Fixes an issue where the previous avatar remains on the header. We start to persist the previous avatar URL and compare it with the newly selected avatar URL. If they are different we start to clear the URLCache because otherwise it will still serve the older image. 

## Test

1. Select a different avatar, or remove the existing avatar (Try both)
2. Kill and reopen the app
3. Observe the correct avatar is visible on the headers

Repeat the test by doing step 1 from a different device/client.

Test 2

- Select an avatar
- Delete the selected avatar
- Restart the app
- Select a new avatar
Observe: Header refreshes
