### PR TITLE
Renaming `Share` to `Share profile`

### DIFF
--- a/GravatarApp/CommonViews/MainMenu/MainMenuOptions.swift
+++ b/GravatarApp/CommonViews/MainMenu/MainMenuOptions.swift
@@ -52,7 +52,7 @@ private enum Localized {
     )
     static let shareTitle: String = NSLocalizedString(
         "MainMenu.Option.share",
-        value: "Share",
+        value: "Share profile",
         comment: "Title for the button to share the user's profile"
     )
     static let aboutTitle: String = NSLocalizedString(

--- a/GravatarApp/Resources/en.lproj/Localizable.strings
+++ b/GravatarApp/Resources/en.lproj/Localizable.strings
@@ -110,7 +110,7 @@
 "MainMenu.Option.about" = "About this app";
 
 /* Title for the button to share the user's profile */
-"MainMenu.Option.share" = "Share";
+"MainMenu.Option.share" = "Share profile";
 
 /* Title for the button to sign out */
 "MainMenu.Option.signOut" = "Sign out";


### PR DESCRIPTION
Closes GRA-678

This PR renames the `Share` button in the Main Menu to `Share profile`.

<img width="40%" alt="CleanShot 2025-08-06 at 16 27 02@2x" src="https://github.com/user-attachments/assets/e4ce1fdb-3411-490b-a0af-2238917156a0" />

To test:

- Run the app
- Open the main menu
  - Check that `Share profile` button is there.
 
