### PR TITLE
Improving analytics on Welcome screen

### DIFF
--- a/GravatarApp/AppRoot/AppEvents.swift
+++ b/GravatarApp/AppRoot/AppEvents.swift
@@ -1,0 +1,39 @@
+import Analytics
+import Foundation
+
+enum AppEvent {
+    enum Screens: String, Encodable {
+        case login
+        case avatars
+        case profile
+        case qr
+        case qrFullScreen = "qr_full_screen"
+        case about
+    }
+
+    static func screenView(screen: AppEvent.Screens) -> AnalyticsEvent {
+        ScreenView(properties: ScreenView.Properties(screen: screen))
+    }
+
+    static func screenLeave(screen: AppEvent.Screens) -> AnalyticsEvent {
+        ScreenLeave(properties: ScreenView.Properties(screen: screen))
+    }
+}
+
+private struct ScreenView: AnalyticsEvent {
+    struct Properties: EventProperties {
+        let screen: AppEvent.Screens
+    }
+
+    let name: String = "screen_view"
+    let properties: EventProperties?
+}
+
+private struct ScreenLeave: AnalyticsEvent {
+    struct Properties: EventProperties {
+        let screen: AppEvent.Screens
+    }
+
+    let name: String = "screen_leave"
+    let properties: EventProperties?
+}

--- a/GravatarApp/Welcome/WelcomeScreenEvent.swift
+++ b/GravatarApp/Welcome/WelcomeScreenEvent.swift
@@ -5,7 +5,7 @@ enum WelcomeScreenEvent {
     static let loginButtonTapped: AnalyticsEvent = LoginButtonTapped()
 
     static let oauthStart: AnalyticsEvent = OAuthStart()
-    static let oauthCanceled: AnalyticsEvent = OAuthCanceled()
+    static let oauthCancelled: AnalyticsEvent = OAuthCancelled()
     static let oauthSuccess: AnalyticsEvent = OAuthSuccess()
     static func oauthError(error: String) -> AnalyticsEvent {
         OAuthError(properties: OAuthError.Properties(error: error))
@@ -42,8 +42,8 @@ private struct OAuthError: AnalyticsEvent {
     let properties: EventProperties?
 }
 
-private struct OAuthCanceled: AnalyticsEvent {
-    let name: String = "oauth_canceled"
+private struct OAuthCancelled: AnalyticsEvent {
+    let name: String = "oauth_cancelled"
     let properties: EventProperties? = nil
 }
 

--- a/GravatarApp/Welcome/WelcomeScreenEvent.swift
+++ b/GravatarApp/Welcome/WelcomeScreenEvent.swift
@@ -2,7 +2,7 @@ import Analytics
 import Foundation
 
 enum WelcomeScreenEvent {
-    static let loginButtonPressed: AnalyticsEvent = LoginButtonPressed()
+    static let loginButtonTapped: AnalyticsEvent = LoginButtonTapped()
 
     static let oauthStart: AnalyticsEvent = OAuthStart()
     static let oauthSuccess: AnalyticsEvent = OAuthSuccess()
@@ -17,8 +17,8 @@ enum WelcomeScreenEvent {
     }
 }
 
-private struct LoginButtonPressed: AnalyticsEvent {
-    let name: String = "login_button_pressed"
+private struct LoginButtonTapped: AnalyticsEvent {
+    let name: String = "login_button_tapped"
     let properties: EventProperties? = nil
 }
 
@@ -33,7 +33,7 @@ private struct OAuthSuccess: AnalyticsEvent {
 }
 
 private struct OAuthError: AnalyticsEvent {
-    struct Properties: Encodable, Sendable {
+    struct Properties: EventProperties {
         let error: String
     }
 
@@ -52,7 +52,7 @@ private struct ProfileFetchSuccess: AnalyticsEvent {
 }
 
 private struct ProfileFetchError: AnalyticsEvent {
-    struct Properties: Encodable, Sendable {
+    struct Properties: EventProperties {
         let error: String
     }
 

--- a/GravatarApp/Welcome/WelcomeScreenEvent.swift
+++ b/GravatarApp/Welcome/WelcomeScreenEvent.swift
@@ -5,6 +5,7 @@ enum WelcomeScreenEvent {
     static let loginButtonTapped: AnalyticsEvent = LoginButtonTapped()
 
     static let oauthStart: AnalyticsEvent = OAuthStart()
+    static let oauthCanceled: AnalyticsEvent = OAuthCanceled()
     static let oauthSuccess: AnalyticsEvent = OAuthSuccess()
     static func oauthError(error: String) -> AnalyticsEvent {
         OAuthError(properties: OAuthError.Properties(error: error))
@@ -39,6 +40,11 @@ private struct OAuthError: AnalyticsEvent {
 
     let name: String = "oauth_error"
     let properties: EventProperties?
+}
+
+private struct OAuthCanceled: AnalyticsEvent {
+    let name: String = "oauth_canceled"
+    let properties: EventProperties? = nil
 }
 
 private struct ProfileFetchStart: AnalyticsEvent {

--- a/GravatarApp/Welcome/WelcomeView.swift
+++ b/GravatarApp/Welcome/WelcomeView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct WelcomeView: View {
     @ObservedObject private var viewModel: WelcomeViewModel
     @Environment(\.analytics) var analytics
+    @State private var hasSessionOnAppear = false
 
     init(viewModel: WelcomeViewModel, userDefaults: UserDefaults = .standard) {
         _viewModel = .init(wrappedValue: viewModel)
@@ -23,9 +24,6 @@ struct WelcomeView: View {
         }
         .modelContext(viewModel.context)
         .onAppear {
-            if !viewModel.hasUserSession {
-                analytics.track(AppEvent.screenView(screen: .login))
-            }
             viewModel.softLogin()
         }
         .onReceive(NotificationCenter.default.publisher(for: .sessionExpired)) { _ in
@@ -87,6 +85,17 @@ struct WelcomeView: View {
             .padding(.bottom, .Global.contentBottomPadding)
             .padding(.horizontal, .Global.contentHorizontalPadding)
             .readableContentWidth()
+        }
+        .onAppear {
+            hasSessionOnAppear = viewModel.hasUserSession
+            if !hasSessionOnAppear {
+                analytics.track(AppEvent.screenView(screen: .login))
+            }
+        }
+        .onDisappear {
+            if !hasSessionOnAppear {
+                analytics.track(AppEvent.screenLeave(screen: .login))
+            }
         }
     }
 

--- a/GravatarApp/Welcome/WelcomeView.swift
+++ b/GravatarApp/Welcome/WelcomeView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 
 struct WelcomeView: View {
     @ObservedObject private var viewModel: WelcomeViewModel
+    @Environment(\.analytics) var analytics
 
     init(viewModel: WelcomeViewModel, userDefaults: UserDefaults = .standard) {
         _viewModel = .init(wrappedValue: viewModel)
@@ -22,6 +23,9 @@ struct WelcomeView: View {
         }
         .modelContext(viewModel.context)
         .onAppear {
+            if !viewModel.hasUserSession {
+                analytics.track(AppEvent.screenView(screen: .login))
+            }
             viewModel.softLogin()
         }
         .onReceive(NotificationCenter.default.publisher(for: .sessionExpired)) { _ in
@@ -145,7 +149,7 @@ struct WelcomeView: View {
 
     var loginButton: some View {
         Button {
-            viewModel.trackLoginButtonTap()
+            analytics.track(WelcomeScreenEvent.loginButtonTapped)
             Task {
                 if viewModel.profileFetchingError != nil, let token = viewModel.localAccessToken {
                     await viewModel.fetchProfile(with: token)

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -51,10 +51,6 @@ class WelcomeViewModel: ObservableObject {
         }.store(in: &cancellables)
     }
 
-    func trackLoginButtonTap() {
-        analytics.track(WelcomeScreenEvent.loginButtonPressed)
-    }
-
     func fetchProfile(with token: String) async {
         defer {
             isLoading = false
@@ -64,7 +60,7 @@ class WelcomeViewModel: ObservableObject {
             analytics.track(WelcomeScreenEvent.profileFetchStart)
             let profile = try await profileService.fetchOwnProfile(token: token)
             analytics.track(WelcomeScreenEvent.profileFetchSuccess)
-            configureSession(profile: profile, accessToken: token)
+            await configureSession(profile: profile, accessToken: token)
             cleanAllErrors()
         } catch {
             if let error = error as? APIError { // Always the case (we need typed throws from the SDK)
@@ -77,12 +73,10 @@ class WelcomeViewModel: ObservableObject {
         }
     }
 
-    private func configureSession(profile: Profile, accessToken: String) {
+    private func configureSession(profile: Profile, accessToken: String) async {
         self.oauthManager.saveToken(AccessToken(token: accessToken), withKey: profile.hash)
 
-        Task {
-            await analytics.setUserName(profile.userLogin)
-        }
+        await analytics.setUserName(profile.userLogin)
         userDefaults.set(profile.hash, forKey: .Gravatar.currentUserKey)
 
         if let userSession {
@@ -118,6 +112,11 @@ class WelcomeViewModel: ObservableObject {
         Task {
             await fetchProfile(with: accessToken)
         }
+    }
+
+    var hasUserSession: Bool {
+        guard let currentUserHash = userDefaults.string(forKey: .Gravatar.currentUserKey) else { return false }
+        return oauthManager.sessionToken(with: currentUserHash)?.token != nil
     }
 
     func logout() async {

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -173,11 +173,15 @@ class WelcomeViewModel: ObservableObject {
             analytics.track(WelcomeScreenEvent.oauthSuccess)
             await fetchProfile(with: token)
         } catch {
-            analytics.track(WelcomeScreenEvent.oauthError(error: error.errorDescription))
-            if error.isAssociatedDomainError {
+            switch error {
+            case let error where error.isAccessDenied || error.isCancelled:
+                analytics.track(WelcomeScreenEvent.oauthCanceled)
+            case let error where error.isAssociatedDomainError:
                 oauthAlertErrorMessage = Localized.secureLoginErrorMessage
-            } else if !(error.isAccessDenied || error.isCancelled) {
+                analytics.track(WelcomeScreenEvent.oauthError(error: error.errorDescription))
+            default:
                 oauthAlertErrorMessage = error.errorDescription
+                analytics.track(WelcomeScreenEvent.oauthError(error: error.errorDescription))
             }
             withAnimation {
                 self.oauthError = error

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -175,7 +175,7 @@ class WelcomeViewModel: ObservableObject {
         } catch {
             switch error {
             case let error where error.isAccessDenied || error.isCancelled:
-                analytics.track(WelcomeScreenEvent.oauthCanceled)
+                analytics.track(WelcomeScreenEvent.oauthCancelled)
             case let error where error.isAssociatedDomainError:
                 oauthAlertErrorMessage = Localized.secureLoginErrorMessage
                 analytics.track(WelcomeScreenEvent.oauthError(error: error.errorDescription))

--- a/GravatarAppTests/Helpers/TrackerMock.swift
+++ b/GravatarAppTests/Helpers/TrackerMock.swift
@@ -1,0 +1,40 @@
+import Analytics
+
+class UserUUIDStorageMock: UserUUIDStorage {
+    var uuid: String?
+
+    func set(_ uuid: String) {
+        self.uuid = uuid
+    }
+}
+
+final class TrackerMock: Tracker, @unchecked Sendable {
+    var configureCalled = false
+    var userProperties: [String: AnyHashable] = [:]
+    var userName: String?
+    var trackedEvents: [(name: String, properties: [String: AnyHashable])] = []
+
+    func track(_ name: String, withCustomProperties properties: [String: AnyHashable]) {
+        trackedEvents.append((name: name, properties: properties))
+    }
+
+    func setUserProperty(_ value: AnyHashable, for key: String) {
+        userProperties[key] = value
+    }
+
+    func setUserName(_ userName: String?, userUUIDStorage: any UserUUIDStorage) {
+        self.userName = userName
+    }
+
+    func configure() {
+        configureCalled = true
+    }
+
+    func tracked(event: AnalyticsEvent, count: Int = 1) -> Bool {
+        trackedEvents.filter { $0.name == event.name }.count == count
+    }
+
+    func tracked(event: AnalyticsEvent, with properties: [String: AnyHashable], count: Int = 1) -> Bool {
+        trackedEvents.filter { event.name == $0.name && $0.properties == properties }.count == count
+    }
+}

--- a/GravatarAppTests/Resources/JSONResponses/fullProfile.json
+++ b/GravatarAppTests/Resources/JSONResponses/fullProfile.json
@@ -1,5 +1,6 @@
 {
     "hash": "somehash",
+    "user_login" : "johnappleseed",
     "display_name": "John Appleseed",
     "profile_url": "https://gravatar.com/notreal",
     "avatar_url": "https://2.gravatar.com/avatar/hashhash",

--- a/GravatarAppTests/WelcomeTests/WelcomeViewModelTests.swift
+++ b/GravatarAppTests/WelcomeTests/WelcomeViewModelTests.swift
@@ -94,7 +94,7 @@ final class WelcomeViewModelTests {
         #expect(model.oauthError != nil)
         #expect(model.profileFetchingError == nil)
 
-        #expect(tracker.tracked(event: WelcomeScreenEvent.oauthError(error: "")))
+        #expect(tracker.tracked(event: WelcomeScreenEvent.oauthCancelled))
         #expect(tracker.tracked(event: WelcomeScreenEvent.oauthSuccess, count: 0))
     }
 

--- a/GravatarAppTests/WelcomeTests/WelcomeViewModelTests.swift
+++ b/GravatarAppTests/WelcomeTests/WelcomeViewModelTests.swift
@@ -1,4 +1,4 @@
-import Analytics
+@testable import Analytics
 import Foundation
 import Gravatar
 @testable import GravatarApp
@@ -11,6 +11,7 @@ final class WelcomeViewModelTests {
     let container = ModelContext.testContainer
     let profileService = TestProfileService()
     let oauthSession = TestOAuthSession(callbackURL: URL(string: "https://some.com")!)
+    let tracker = TrackerMock()
 
     lazy var oauthManager = OAuthManager(
         authenticationSession: oauthSession,
@@ -21,12 +22,13 @@ final class WelcomeViewModelTests {
     lazy var model = WelcomeViewModel(
         oauthManager: oauthManager,
         userDefaults: .testUserDefaults,
+        analytics: Analytics(tracker: tracker, userUUIDStorage: UserUUIDStorageMock()),
         profileService: profileService,
         context: container.mainContext
     )
 
     init() async throws {
-        Analytics.setPushEventsToRemote(false)
+        Analytics.setPushEventsToRemote(true)
         UserDefaults.deleteTestData()
     }
 
@@ -37,6 +39,12 @@ final class WelcomeViewModelTests {
         #expect(model.userSession != nil)
         #expect(model.userSession?.profile.fullName == "John Appleseed")
         #expect(model.userSession?.accessToken == "token")
+
+        #expect(tracker.tracked(event: WelcomeScreenEvent.oauthStart))
+        #expect(tracker.tracked(event: WelcomeScreenEvent.oauthSuccess))
+        #expect(tracker.tracked(event: WelcomeScreenEvent.profileFetchStart))
+        #expect(tracker.tracked(event: WelcomeScreenEvent.profileFetchSuccess))
+        #expect(tracker.userName != nil)
     }
 
     @Test("Logout should reset user session")
@@ -46,10 +54,12 @@ final class WelcomeViewModelTests {
         #expect(model.userSession != nil)
         #expect(model.userSession?.profile.fullName == "John Appleseed")
         #expect(model.userSession?.accessToken == "token")
+        #expect(tracker.userName != nil)
 
         await model.logout()
 
         #expect(model.userSession == nil)
+        #expect(tracker.userName == nil)
     }
 
     @Test("Soft login should succeed")
@@ -68,6 +78,10 @@ final class WelcomeViewModelTests {
         #expect(model.userSession != nil)
         #expect(model.userSession?.profile.fullName == "John Appleseed")
         #expect(model.userSession?.accessToken == "token")
+
+        // Don't track oauth success on soft login. Expected 1 event from requestOAuthToken()
+        #expect(tracker.tracked(event: WelcomeScreenEvent.oauthSuccess, count: 1))
+        #expect(tracker.tracked(event: WelcomeScreenEvent.profileFetchSuccess, count: 1))
     }
 
     @Test("Oauth error should not create user session")
@@ -79,6 +93,9 @@ final class WelcomeViewModelTests {
         #expect(model.userSession == nil)
         #expect(model.oauthError != nil)
         #expect(model.profileFetchingError == nil)
+
+        #expect(tracker.tracked(event: WelcomeScreenEvent.oauthError(error: "")))
+        #expect(tracker.tracked(event: WelcomeScreenEvent.oauthSuccess, count: 0))
     }
 
     @Test("Oauth error clears after successful login")
@@ -108,6 +125,9 @@ final class WelcomeViewModelTests {
         #expect(model.userSession == nil)
         #expect(model.profileFetchingError != nil)
         #expect(model.oauthError == nil)
+
+        #expect(tracker.tracked(event: WelcomeScreenEvent.profileFetchError(error: "")))
+        #expect(tracker.tracked(event: WelcomeScreenEvent.profileFetchSuccess, count: 0))
     }
 
     @Test("Profile error clears after successful profile request")

--- a/Packages/Analytics/Sources/Analytics/Event.swift
+++ b/Packages/Analytics/Sources/Analytics/Event.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public typealias EventProperties = (any Encodable & Sendable)
+public typealias EventProperties = (Encodable & Sendable)
 
 public protocol AnalyticsEvent: Sendable {
     var name: String { get }


### PR DESCRIPTION
Closes GRA-717

This PR adds:
- App-wide events for `screenView` and `screenLeave`
- Utilities to unit test tracked analytics events
- Tracking analytics expectations added on WelcomeScreen` tests.

This is due to the view hierarchy in place. Since `RootTabView` is part of `WelcomeView`, `onDisappear` is never called on `WelcomeView` and `onAppear` is only called on launch once.

Since this PR brings helpful utilities for the rest of the Analytics work, I prefer to merge this fast and work on this hierarchy change later on.

### To test:
This PR mostly focuses on Unit Tests, plus a few tweaks on `WelcomeScreenViewModel`

- Smoke-test welcome screen events.