### PR TITLE
Analytics profile screen

### DIFF
--- a/GravatarApp/AppRoot/AppEvents.swift
+++ b/GravatarApp/AppRoot/AppEvents.swift
@@ -18,6 +18,10 @@ enum AppEvent {
     static func screenLeave(screen: AppEvent.Screens) -> AnalyticsEvent {
         CommonAnalyticsEvent(name: "screen_leave", properties: ScreenEventProperties(screen: screen))
     }
+
+    static func mainMenuTapped(screen: AppEvent.Screens) -> AnalyticsEvent {
+        CommonAnalyticsEvent(name: "mainmenu_tapped", properties: ScreenEventProperties(screen: screen))
+    }
 }
 
 private struct ScreenEventProperties: EventProperties {

--- a/GravatarApp/AvatarPicker/AvatarPickerViewEvents.swift
+++ b/GravatarApp/AvatarPicker/AvatarPickerViewEvents.swift
@@ -2,16 +2,12 @@ import Analytics
 import Foundation
 
 enum AvatarPickerViewEvents {
-    static let screen: String = "avatars"
     static let screenView: AnalyticsEvent = AppEvent.screenView(screen: .avatars)
     static let screenLeave: AnalyticsEvent = AppEvent.screenLeave(screen: .avatars)
-    static let mainMenuTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "mainmenu_tapped", properties: MenuEventProperties(screen: .avatars))
+    static let mainMenuTapped: AnalyticsEvent = AppEvent.mainMenuTapped(screen: .avatars)
+
     static let avatarsGridItemTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "avatars_grid_item_tapped")
     static let avatarsCameraButtonTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "avatars_camera_button_tapped")
     static let avatarsPhotosButtonTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "avatars_photos_button_tapped")
     static let avatarsAIButtonTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "avatars_ai_button_tapped")
-}
-
-private struct MenuEventProperties: Encodable & Sendable {
-    let screen: AppEvent.Screens
 }

--- a/GravatarApp/CommonViews/AnimatedHeaderScrollView/AnimatedHeaderScrollView.swift
+++ b/GravatarApp/CommonViews/AnimatedHeaderScrollView/AnimatedHeaderScrollView.swift
@@ -189,7 +189,8 @@ struct AnimatedHeaderScrollView<ContentView: View, ScrollableHeader: View, Stick
             profile: .testProfile,
             topPadding: topPadding,
             imageURL: imageURL,
-            forceRefresh: .constant(false)
+            forceRefresh: .constant(false),
+            onProfileButtonTapped: {}
         )
     } stickyHeader: { opacity, safeAreaInsets in
         ProfileEditorStickyHeaderView(

--- a/GravatarApp/ProfileEditor/Header/ProfileEditorScrollableHeaderView.swift
+++ b/GravatarApp/ProfileEditor/Header/ProfileEditorScrollableHeaderView.swift
@@ -8,6 +8,7 @@ struct ProfileEditorScrollableHeaderView: View {
     @Binding var forceRefresh: Bool
 
     @Environment(\.openURL) var openURL
+    let onProfileButtonTapped: () -> Void
 
     var body: some View {
         BouncyImageBackgroundHeaderView(
@@ -55,6 +56,7 @@ struct ProfileEditorScrollableHeaderView: View {
 
     func profileURLButton() -> some View {
         Button {
+            onProfileButtonTapped()
             guard let url = URL(string: profile.profileUrl) else { return }
             openURL(url)
         } label: {
@@ -83,7 +85,8 @@ struct ProfileEditorScrollableHeaderView: View {
                 profile: .testProfile,
                 topPadding: geo.safeAreaInsets.top,
                 imageURL: imageURL,
-                forceRefresh: .constant(false)
+                forceRefresh: .constant(false),
+                onProfileButtonTapped: {}
             )
             Spacer()
         }.ignoresSafeArea()

--- a/GravatarApp/ProfileEditor/ProfileEditorEvents.swift
+++ b/GravatarApp/ProfileEditor/ProfileEditorEvents.swift
@@ -1,0 +1,12 @@
+import Analytics
+import Foundation
+
+enum ProfileEditorEvents {
+    static let screenView: AnalyticsEvent = AppEvent.screenView(screen: .profile)
+    static let screenLeave: AnalyticsEvent = AppEvent.screenLeave(screen: .profile)
+    static let mainMenuTapped: AnalyticsEvent = AppEvent.mainMenuTapped(screen: .profile)
+
+    static let profileHeaderLinkTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "profile_headerlink_tapped")
+    static let profileCancelChangesTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "profile_cancel_changes_tapped")
+    static let profileSaveChangesTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "profile_save_changes_tapped")
+}

--- a/GravatarApp/ProfileEditor/ProfileEditorView.swift
+++ b/GravatarApp/ProfileEditor/ProfileEditorView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct ProfileEditorView: View {
     @ObservedObject var viewModel: EditProfileViewModel
     @Binding var forceRefreshAvatar: Bool
+    @Environment(\.analytics) var analytics
 
     var headerAvatarURL: URL? {
         AvatarURL.preferredURL(for: viewModel.userSession.profile.hash)
@@ -15,7 +16,10 @@ struct ProfileEditorView: View {
                 profile: viewModel.userSession.profile,
                 topPadding: topPadding,
                 imageURL: headerAvatarURL,
-                forceRefresh: $forceRefreshAvatar
+                forceRefresh: $forceRefreshAvatar,
+                onProfileButtonTapped: {
+                    analytics.track(ProfileEditorEvents.profileHeaderLinkTapped)
+                }
             )
         } stickyHeader: { opacity, safeArea in
             ProfileEditorStickyHeaderView(
@@ -29,7 +33,9 @@ struct ProfileEditorView: View {
             ProfileEditContentView(viewModel: viewModel)
                 .readableContentWidth()
         } mainMenuButton: {
-            MainMenu(profile: viewModel.userSession.profile) {}
+            MainMenu(profile: viewModel.userSession.profile) {
+                analytics.track(ProfileEditorEvents.mainMenuTapped)
+            }
         } onRefresh: {
             await viewModel.fetchProfile()
             forceRefreshAvatar = true
@@ -37,7 +43,11 @@ struct ProfileEditorView: View {
         .safeAreaInset(edge: .bottom, alignment: .center, spacing: nil) {
             Group {
                 if viewModel.hasUnsavedChanges {
-                    SaveToolbar(viewModel: viewModel)
+                    SaveToolbar(viewModel: viewModel) {
+                        analytics.track(ProfileEditorEvents.profileSaveChangesTapped)
+                    } onCancel: {
+                        analytics.track(ProfileEditorEvents.profileCancelChangesTapped)
+                    }
                 } else {
                     // Keep the save area of the same height of the toolbar
                     // It will grow acordingly with different font sizes
@@ -48,6 +58,12 @@ struct ProfileEditorView: View {
                 }
             }
             .animation(.smooth(duration: 0.3), value: viewModel.hasUnsavedChanges)
+        }
+        .onAppear {
+            analytics.track(ProfileEditorEvents.screenView)
+        }
+        .onDisappear {
+            analytics.track(ProfileEditorEvents.screenLeave)
         }
     }
 }

--- a/GravatarApp/ProfileEditor/SaveToolbar.swift
+++ b/GravatarApp/ProfileEditor/SaveToolbar.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct SaveToolbar: View {
     @ObservedObject var viewModel: EditProfileViewModel
+    let onSave: () -> Void
+    let onCancel: () -> Void
 
     var body: some View {
         HStack {
@@ -14,6 +16,7 @@ struct SaveToolbar: View {
                     .opacity(0)
             } else {
                 Button {
+                    onCancel()
                     viewModel.removeUnsavedChanges()
                 } label: {
                     Text(ProfileEditLocalization.cancelButtonTitle)
@@ -22,6 +25,7 @@ struct SaveToolbar: View {
                 .buttonStyle(.actionButton(style: .secondary))
 
                 Button {
+                    onSave()
                     Task {
                         await viewModel.save()
                     }
@@ -47,6 +51,6 @@ struct SaveToolbar: View {
         profile: .testProfile,
         accessToken: "",
         context: .testContext
-    )))
+    )), onSave: {}, onCancel: {})
 }
 #endif

--- a/GravatarAppTests/ProfileTests/ProfileEditorScrollableHeaderViewTest.swift
+++ b/GravatarAppTests/ProfileTests/ProfileEditorScrollableHeaderViewTest.swift
@@ -13,7 +13,8 @@ struct ProfileEditorScrollableHeaderViewTest {
             profile: .full,
             topPadding: 0,
             imageURL: nil,
-            forceRefresh: .constant(false)
+            forceRefresh: .constant(false),
+            onProfileButtonTapped: {}
         )
         .fixedSize(horizontal: false, vertical: true)
         .frame(width: ViewImageConfig.iPhone13Pro.size?.width ?? 0)
@@ -39,7 +40,8 @@ struct ProfileEditorScrollableHeaderViewTest {
                 profile: profile,
                 topPadding: 0,
                 imageURL: nil,
-                forceRefresh: .constant(false)
+                forceRefresh: .constant(false),
+                onProfileButtonTapped: {}
             )
         }
         .frame(width: ViewImageConfig.iPhone13Pro.size?.width ?? 0, height: 350)

--- a/GravatarAppTests/ProfileTests/SaveToolbarTests.swift
+++ b/GravatarAppTests/ProfileTests/SaveToolbarTests.swift
@@ -16,7 +16,7 @@ struct SaveToolbarTests {
 
     @Test("Save Profile Toolbar initial state")
     func saveToolbarSnapshot() async throws {
-        let view = SaveToolbar(viewModel: viewModel)
+        let view = SaveToolbar(viewModel: viewModel, onSave: {}, onCancel: {})
             .frame(width: ViewImageConfig.iPhone13Pro.size?.width ?? 0)
 
         assertSnapshots(
@@ -30,7 +30,7 @@ struct SaveToolbarTests {
 
     @Test("Save Profile Toolbar on saving state")
     func saveToolbarSnapshotSaving() async throws {
-        let view = SaveToolbar(viewModel: viewModel)
+        let view = SaveToolbar(viewModel: viewModel, onSave: {}, onCancel: {})
             .frame(width: ViewImageConfig.iPhone13Pro.size?.width ?? 0)
 
         viewModel.isSaving = true


### PR DESCRIPTION
Closes GRA-719

This PR adds analytics events to the Profile editor screen:

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-54ef2ea9-7fff-b327-a8e2-eb91e806ab75"><div dir="ltr" style="margin-left:0pt;" align="left">
  | Event name | Properties | Notes
-- | -- | -- | --
  | screen_view | screen: profile |  
  | screen_leave | screen: profile |  
1 | mainmenu_tapped | screen: profile |  
2 | profile_headerlink_tapped |   |  
3 | profile_cancel_changes_tapped |   |  
4 | profile_save_changes_tapped |   |  
</div><br /></b>

### To test:

- Check that the events are triggered as expected.