### PR TITLE
Analytics on QR screen

### DIFF
--- a/GravatarApp/ProfileEditor/ProfileEditorEvents.swift
+++ b/GravatarApp/ProfileEditor/ProfileEditorEvents.swift
@@ -1,5 +1,4 @@
 import Analytics
-import Foundation
 
 enum ProfileEditorEvents {
     static let screenView: AnalyticsEvent = AppEvent.screenView(screen: .profile)

--- a/GravatarApp/Share/QRScreenEvents.swift
+++ b/GravatarApp/Share/QRScreenEvents.swift
@@ -13,6 +13,10 @@ enum QRScreenEvents {
     static func fieldToggled(isOn: Bool, field: FieldToggle.Field) -> AnalyticsEvent {
         CommonAnalyticsEvent(name: "qr_field_toggled", properties: FieldToggle(isOn: isOn, field: field.rawValue))
     }
+
+    static let qrFullScreenView: AnalyticsEvent = AppEvent.screenView(screen: .qrFullScreen)
+    static let qrFullScreenLeave: AnalyticsEvent = AppEvent.screenLeave(screen: .qrFullScreen)
+    static let qrFullScreenCloseButtonTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "qr_full_screen_close_button_tapped")
 }
 
 extension QRScreenEvents {

--- a/GravatarApp/Share/QRScreenEvents.swift
+++ b/GravatarApp/Share/QRScreenEvents.swift
@@ -1,0 +1,51 @@
+import Analytics
+
+enum QRScreenEvents {
+    static let screenView: AnalyticsEvent = AppEvent.screenView(screen: .qr)
+    static let screenLeave: AnalyticsEvent = AppEvent.screenLeave(screen: .qr)
+    static let mainMenuTapped: AnalyticsEvent = AppEvent.mainMenuTapped(screen: .qr)
+
+    static let headerShareTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "qr_header_share_tapped")
+    static let headerExpandTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "qr_header_expand_tapped")
+    static let previewButtonTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "qr_preview_tapped")
+    static let privateInfoButtonTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "qr_private_contact_info_button_tapped")
+
+    static func fieldToggled(isOn: Bool, field: FieldToggle.Field) -> AnalyticsEvent {
+        CommonAnalyticsEvent(name: "qr_field_toggled", properties: FieldToggle(isOn: isOn, field: field.rawValue))
+    }
+}
+
+extension QRScreenEvents {
+    struct FieldToggle: EventProperties {
+        enum Field {
+            case email
+            case phone
+            case name
+            case location
+            case jobTitle
+            case company
+            case aboutMe
+            case profileURL
+            case verifiedAccount(String)
+        }
+        let isOn: Bool
+        let field: String
+    }
+}
+
+extension QRScreenEvents.FieldToggle.Field {
+    fileprivate var rawValue: String {
+        switch self {
+        case .email, .phone, .name, .company, .location:
+            return String(describing: self)
+        case .jobTitle: 
+            return "job_title"
+        case .aboutMe: 
+            return "about_me"
+        case .profileURL: 
+            return "profile_url"
+        case .verifiedAccount(let service):
+            return "verified_account_\(service)"
+        }
+    }
+}

--- a/GravatarApp/Share/QRScreenEvents.swift
+++ b/GravatarApp/Share/QRScreenEvents.swift
@@ -32,6 +32,7 @@ extension QRScreenEvents {
             case profileURL
             case verifiedAccount(String)
         }
+
         let isOn: Bool
         let field: String
     }
@@ -41,15 +42,15 @@ extension QRScreenEvents.FieldToggle.Field {
     fileprivate var rawValue: String {
         switch self {
         case .email, .phone, .name, .company, .location:
-            return String(describing: self)
-        case .jobTitle: 
-            return "job_title"
-        case .aboutMe: 
-            return "about_me"
-        case .profileURL: 
-            return "profile_url"
+            String(describing: self)
+        case .jobTitle:
+            "job_title"
+        case .aboutMe:
+            "about_me"
+        case .profileURL:
+            "profile_url"
         case .verifiedAccount(let service):
-            return "verified_account_\(service)"
+            "verified_account_\(service)"
         }
     }
 }

--- a/GravatarApp/Share/ShareContentView.swift
+++ b/GravatarApp/Share/ShareContentView.swift
@@ -6,6 +6,7 @@ struct ShareContentView: View {
     @ObservedObject var viewModel: ShareViewModel
     @FocusState var focusState: Bool
     @EnvironmentObject var modalManager: ModalPresentationManager
+    @Environment(\.analytics) var analytics
 
     var body: some View {
         VStack(spacing: .Global.verticalSectionSpacing) {
@@ -141,6 +142,7 @@ struct ShareContentView: View {
             .foregroundStyle(.secondary)
 
         Button(Localized.previewButtonTitle) {
+            analytics.track(QRScreenEvents.previewButtonTapped)
             viewModel.previewVCard()
         }
         .buttonStyle(.actionButton())
@@ -153,6 +155,7 @@ struct ShareContentView: View {
         showExclamationButton: Bool = false
     ) -> some View {
         Button {
+            analytics.track(QRScreenEvents.privateInfoButtonTapped)
             modalManager.present {
                 PrivateInformationAlertView(onDismiss: {
                     modalManager.dismiss()

--- a/GravatarApp/Share/ShareFields/ShareFieldsSelectionStore.swift
+++ b/GravatarApp/Share/ShareFields/ShareFieldsSelectionStore.swift
@@ -1,8 +1,10 @@
 import Gravatar
 import SwiftUI
+import Analytics
 
 class ShareFieldsSelectionStore: ObservableObject {
     private let userDefaults: UserDefaults
+    private let analytics: Analytics
 
     private enum Key {
         static let shareEmail = "shareEmail"
@@ -16,35 +18,59 @@ class ShareFieldsSelectionStore: ObservableObject {
     }
 
     @Published var email: Bool {
-        didSet { userDefaults.set(email, forKey: Key.shareEmail) }
+        didSet {
+            analytics.track(QRScreenEvents.fieldToggled(isOn: email, field: .email))
+            userDefaults.set(email, forKey: Key.shareEmail)
+        }
     }
 
     @Published var phone: Bool {
-        didSet { userDefaults.set(phone, forKey: Key.sharePhone) }
+        didSet {
+            analytics.track(QRScreenEvents.fieldToggled(isOn: phone, field: .phone))
+            userDefaults.set(phone, forKey: Key.sharePhone)
+        }
     }
 
     @Published var name: Bool {
-        didSet { userDefaults.set(name, forKey: Key.shareName) }
+        didSet {
+            analytics.track(QRScreenEvents.fieldToggled(isOn: name, field: .name))
+            userDefaults.set(name, forKey: Key.shareName)
+        }
     }
 
     @Published var location: Bool {
-        didSet { userDefaults.set(location, forKey: Key.shareLocation) }
+        didSet {
+            analytics.track(QRScreenEvents.fieldToggled(isOn: location, field: .location))
+            userDefaults.set(location, forKey: Key.shareLocation)
+        }
     }
 
     @Published var jobTitle: Bool {
-        didSet { userDefaults.set(jobTitle, forKey: Key.shareJobTitle) }
+        didSet {
+            analytics.track(QRScreenEvents.fieldToggled(isOn: jobTitle, field: .jobTitle))
+            userDefaults.set(jobTitle, forKey: Key.shareJobTitle)
+        }
     }
 
     @Published var company: Bool {
-        didSet { userDefaults.set(company, forKey: Key.shareCompany) }
+        didSet {
+            analytics.track(QRScreenEvents.fieldToggled(isOn: company, field: .company))
+            userDefaults.set(company, forKey: Key.shareCompany)
+        }
     }
 
     @Published var description: Bool {
-        didSet { userDefaults.set(description, forKey: Key.shareDescription) }
+        didSet {
+            analytics.track(QRScreenEvents.fieldToggled(isOn: description, field: .aboutMe))
+            userDefaults.set(description, forKey: Key.shareDescription)
+        }
     }
 
     @Published var profileURL: Bool {
-        didSet { userDefaults.set(profileURL, forKey: Key.shareProfileURL) }
+        didSet {
+            analytics.track(QRScreenEvents.fieldToggled(isOn: profileURL, field: .profileURL))
+            userDefaults.set(profileURL, forKey: Key.shareProfileURL)
+        }
     }
 
     func account(_ verifiedAccount: VerifiedAccount) -> Bool {
@@ -52,12 +78,14 @@ class ShareFieldsSelectionStore: ObservableObject {
     }
 
     func set(_ verifiedAccount: VerifiedAccount, to value: Bool) {
+        analytics.track(QRScreenEvents.fieldToggled(isOn: value, field: .verifiedAccount(verifiedAccount.serviceType)))
         userDefaults.set(value, forKey: verifiedAccount.url)
         objectWillChange.send()
     }
 
-    init(userDefaults: UserDefaults = .standard) {
+    init(userDefaults: UserDefaults = .standard, analytics: Analytics = .shared) {
         self.userDefaults = userDefaults
+        self.analytics = analytics
 
         email = userDefaults.bool(forKey: Key.shareEmail, default: true)
         phone = userDefaults.bool(forKey: Key.sharePhone, default: true)

--- a/GravatarApp/Share/ShareFields/ShareFieldsSelectionStore.swift
+++ b/GravatarApp/Share/ShareFields/ShareFieldsSelectionStore.swift
@@ -1,6 +1,6 @@
+import Analytics
 import Gravatar
 import SwiftUI
-import Analytics
 
 class ShareFieldsSelectionStore: ObservableObject {
     private let userDefaults: UserDefaults

--- a/GravatarApp/Share/ShareView.swift
+++ b/GravatarApp/Share/ShareView.swift
@@ -6,9 +6,10 @@ struct ShareView: View {
     @ObservedObject var viewModel: ShareViewModel
 
     @Binding var forceRefreshAvatar: Bool
-    @State var scrollOffset: CGFloat = 0
-    @State var windowWidth: CGFloat = 0
-    @State var safeAreaInsets: EdgeInsets = .init()
+    @State private var scrollOffset: CGFloat = 0
+    @State private var windowWidth: CGFloat = 0
+    @State private var safeAreaInsets: EdgeInsets = .init()
+    @Environment(\.analytics) private var analytics
 
     var headerAvatarURL: URL? {
         AvatarURL.preferredURL(for: viewModel.profile.hash)
@@ -42,7 +43,13 @@ struct ShareView: View {
                     imageURL: headerAvatarURL,
                     forceRefresh: $forceRefreshAvatar,
                     windowWidth: $windowWidth,
-                    onShareButtonPressed: onShareButtonPressed
+                    onShareButtonPressed: onShareButtonPressed,
+                    onMainMenuButtonPressed: {
+                        analytics.track(QRScreenEvents.mainMenuTapped)
+                    },
+                    onFullScreenButtonPressed: {
+                        analytics.track(QRScreenEvents.headerExpandTapped)
+                    }
                 )
                 ShareContentView(viewModel: viewModel)
             }
@@ -80,9 +87,16 @@ struct ShareView: View {
                 Spacer()
             }
         })
+        .onAppear {
+            analytics.track(QRScreenEvents.screenView)
+        }
+        .onDisappear {
+            analytics.track(QRScreenEvents.screenLeave)
+        }
     }
 
     func onShareButtonPressed() {
+        analytics.track(QRScreenEvents.headerShareTapped)
         Task {
             await viewModel.shareVCard()
         }

--- a/GravatarApp/Share/ShareViewModel.swift
+++ b/GravatarApp/Share/ShareViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import Gravatar
 import SwiftUI
+import Analytics
 
 @MainActor
 class ShareViewModel: ObservableObject {
@@ -35,14 +36,15 @@ class ShareViewModel: ObservableObject {
         userSession: UserSession,
         urlSession: URLSessionProtocol? = nil,
         networkMonitor: NetworkMonitor = SystemNetworkMonitor.shared,
-        userDefaults: UserDefaults = .standard
+        userDefaults: UserDefaults = .standard,
+        analytics: Analytics = .shared
     ) {
         self.userSession = userSession
         self.profile = userSession.profile
         self.qrGenerator = QRGenerator()
         self.urlSession = urlSession ?? GravatarURLSession.shared
         self.networkMonitor = networkMonitor
-        self.share = .init(userDefaults: userDefaults)
+        self.share = .init(userDefaults: userDefaults, analytics: analytics)
         self.userDefaults = userDefaults
 
         storedUserEmail = userDefaults.string(forKey: StorageKeys.email) ?? ""

--- a/GravatarApp/Share/ShareViewModel.swift
+++ b/GravatarApp/Share/ShareViewModel.swift
@@ -1,7 +1,7 @@
+import Analytics
 import Combine
 import Gravatar
 import SwiftUI
-import Analytics
 
 @MainActor
 class ShareViewModel: ObservableObject {

--- a/GravatarApp/Share/ShareViews/ShareHeaderView.swift
+++ b/GravatarApp/Share/ShareViews/ShareHeaderView.swift
@@ -11,6 +11,8 @@ struct ShareHeaderView<QRImage: View>: View {
     @Environment(\.openURL) var openURL
 
     let onShareButtonPressed: (() -> Void)?
+    let onMainMenuButtonPressed: (() -> Void)?
+    let onFullScreenButtonPressed: (() -> Void)?
 
     private var qrImage: () -> QRImage
 
@@ -43,7 +45,9 @@ struct ShareHeaderView<QRImage: View>: View {
         imageURL: URL?,
         forceRefresh: Binding<Bool>,
         windowWidth: Binding<CGFloat>,
-        onShareButtonPressed: (() -> Void)? = nil
+        onShareButtonPressed: (() -> Void)? = nil,
+        onMainMenuButtonPressed: (() -> Void)? = nil,
+        onFullScreenButtonPressed: (() -> Void)? = nil
     ) {
         self.profile = profile
         self.topPadding = topPadding
@@ -52,6 +56,8 @@ struct ShareHeaderView<QRImage: View>: View {
         self._windowWidth = windowWidth
         self.qrImage = qrImage
         self.onShareButtonPressed = onShareButtonPressed
+        self.onMainMenuButtonPressed = onMainMenuButtonPressed
+        self.onFullScreenButtonPressed = onFullScreenButtonPressed
     }
 
     var body: some View {
@@ -112,9 +118,11 @@ struct ShareHeaderView<QRImage: View>: View {
 
     @ViewBuilder
     var buttonsSection: some View {
-        MainMenu(profile: profile) {}
-            // skip forced dark mode coming from parent view (Bouncy)
-            .environment(\.colorScheme, UITraitCollection.current.userInterfaceStyle == .dark ? .dark : .light)
+        MainMenu(profile: profile) {
+            onMainMenuButtonPressed?()
+        }
+        // skip forced dark mode coming from parent view (Bouncy)
+        .environment(\.colorScheme, UITraitCollection.current.userInterfaceStyle == .dark ? .dark : .light)
 
         CircularButton {
             onShareButtonPressed?()
@@ -127,6 +135,7 @@ struct ShareHeaderView<QRImage: View>: View {
          }
          */
         CircularButton {
+            onFullScreenButtonPressed?()
             presentFullScreen = true
         } image: {
             Image(.enlargeIcon)

--- a/GravatarApp/Share/ShareViews/ShareQRFullScreenView.swift
+++ b/GravatarApp/Share/ShareViews/ShareQRFullScreenView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct ShareQRFullScreenView<QRImage: View>: View {
+    @Environment(\.analytics) var analytics
+
     @Binding var presentFullScreen: Bool
     let topPadding: CGFloat
     let imageURL: URL?
@@ -43,7 +45,11 @@ struct ShareQRFullScreenView<QRImage: View>: View {
         }
         .environment(\.colorScheme, .dark)
         .onAppear {
+            analytics.track(QRScreenEvents.qrFullScreenView)
             incrementBrightness()
+        }
+        .onDisappear {
+            analytics.track(QRScreenEvents.qrFullScreenLeave)
         }
         .onChange(of: presentFullScreen) { _, newValue in
             if !newValue {
@@ -80,6 +86,7 @@ struct ShareQRFullScreenView<QRImage: View>: View {
 
     var closeButton: some View {
         CircularButton {
+            analytics.track(QRScreenEvents.qrFullScreenCloseButtonTapped)
             presentFullScreen = false
         } image: {
             Image(systemName: "xmark")

--- a/GravatarAppTests/AvatarTests/AvatarPickerViewEventsTests.swift
+++ b/GravatarAppTests/AvatarTests/AvatarPickerViewEventsTests.swift
@@ -7,21 +7,21 @@ struct AvatarPickerViewEventsTests {
     func screenView() async throws {
         let event = AvatarPickerViewEvents.screenView
         #expect(event.name == "screen_view")
-        #expect(event.jsonProperties?["screen"] as? String == "avatars")
+        #expect(event.dictionaryProperties?["screen"] as? String == "avatars")
     }
 
     @Test
     func screenLeave() async throws {
         let event = AvatarPickerViewEvents.screenLeave
         #expect(event.name == "screen_leave")
-        #expect(event.jsonProperties?["screen"] as? String == "avatars")
+        #expect(event.dictionaryProperties?["screen"] as? String == "avatars")
     }
 
     @Test
     func mainMenuTapped() async throws {
         let event = AvatarPickerViewEvents.mainMenuTapped
         #expect(event.name == "mainmenu_tapped")
-        #expect(event.jsonProperties?["screen"] as? String == "avatars")
+        #expect(event.dictionaryProperties?["screen"] as? String == "avatars")
     }
 
     @Test

--- a/GravatarAppTests/ShareScreenTests/ShareQRFillScreenViewTests.swift
+++ b/GravatarAppTests/ShareScreenTests/ShareQRFillScreenViewTests.swift
@@ -1,3 +1,4 @@
+import Analytics
 @testable import GravatarApp
 import SnapshotTesting
 import SwiftUI
@@ -19,6 +20,7 @@ struct ShareQRFillScreenViewTests {
                 windowWidth: geometry.size.width,
                 qrImage: { Image.fallbakQRCodeImage }
             )
+            .environment(\.analytics, Analytics.test)
         }
         .background(Color.secondary)
 

--- a/GravatarAppTests/ShareScreenTests/ShareViewModelTests.swift
+++ b/GravatarAppTests/ShareScreenTests/ShareViewModelTests.swift
@@ -1,3 +1,4 @@
+import Analytics
 import Foundation
 import Gravatar
 @testable import GravatarApp
@@ -126,7 +127,8 @@ private func createViewModel(_ testUnitName: String = #function) -> ShareViewMod
         urlSession: URLSessionMock(),
         networkMonitor: TestNetworkMonitor(),
         // These tests run in parallel, so we need different UserDefaults for each one of them.
-        userDefaults: .testUserDefaults(named: testUnitName)
+        userDefaults: .testUserDefaults(named: testUnitName),
+        analytics: Analytics.test
     )
     viewModel.storedUserEmail = "notreal@example.com"
     viewModel.storedPhoneNumber = "+1234567890"

--- a/GravatarAppTests/WelcomeTests/WelcomeViewTests.swift
+++ b/GravatarAppTests/WelcomeTests/WelcomeViewTests.swift
@@ -8,7 +8,11 @@ import Testing
 @Suite(.snapshots(record: .failed, diffTool: .ksdiff))
 @MainActor
 struct WelcomeViewTests {
-    let viewModel = WelcomeViewModel(userDefaults: UserDefaults(suiteName: "tests")!, context: .testContext)
+    let viewModel = WelcomeViewModel(
+        userDefaults: UserDefaults(suiteName: "tests")!,
+        analytics: Analytics.test,
+        context: .testContext
+    )
 
     @Test("Welcome view clean state")
     @MainActor

--- a/Packages/Analytics/Sources/Analytics/Analytics.swift
+++ b/Packages/Analytics/Sources/Analytics/Analytics.swift
@@ -27,7 +27,7 @@ public actor Analytics {
 
     public nonisolated
     func track(_ event: AnalyticsEvent) {
-        let properties = event.jsonProperties ?? [:]
+        let properties = event.dictionaryProperties ?? [:]
 
         if Self.pushEventsToRemote {
             tracker.track(event.name, withCustomProperties: properties)
@@ -35,7 +35,7 @@ public actor Analytics {
 
         #if DEBUG
         let trackingText = !Self.pushEventsToRemote ? " (Locally)" : ""
-        logger.debug("🔹 Tracking\(trackingText): \(event.name); properties: \(properties)")
+        logger.debug("🔹 Tracking\(trackingText): \(event.name); properties: \(event.jsonStringProperties ?? "{}")")
         #endif
     }
 

--- a/Packages/Analytics/Sources/Analytics/Analytics.swift
+++ b/Packages/Analytics/Sources/Analytics/Analytics.swift
@@ -34,7 +34,8 @@ public actor Analytics {
         }
 
         #if DEBUG
-        let trackingText = !Self.pushEventsToRemote ? " (Locally)" : ""
+        let isMockTracker = String(describing: type(of: tracker)).contains("TrackerMock")
+        let trackingText = !Self.pushEventsToRemote || isMockTracker ? " (Locally)" : ""
         logger.debug("🔹 Tracking\(trackingText): \(event.name); properties: \(event.jsonStringProperties ?? "{}")")
         #endif
     }

--- a/Packages/Analytics/Sources/Analytics/Event.swift
+++ b/Packages/Analytics/Sources/Analytics/Event.swift
@@ -8,13 +8,22 @@ public protocol AnalyticsEvent: Sendable {
 }
 
 extension AnalyticsEvent {
-    var jsonProperties: [String: AnyHashable]? {
+    var dictionaryProperties: [String: AnyHashable]? {
         guard
-            let properties,
-            let data = try? JSONEncoder.snakeCaseEncoder.encode(properties)
+            let data = jsonDataProperties
         else { return nil }
 
         return (try? JSONSerialization.jsonObject(with: data)).flatMap { $0 as? [String: AnyHashable] }
+    }
+
+    var jsonDataProperties: Data? {
+        guard let properties else { return nil }
+        return try? JSONEncoder.snakeCaseEncoder.encode(properties)
+    }
+
+    var jsonStringProperties: String? {
+        guard let data = jsonDataProperties else { return nil }
+        return String(data: data, encoding: .utf8)
     }
 }
 


### PR DESCRIPTION
Closes GRA-720

Adding analytics events for the QR screen:

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-50a18cd2-7fff-74cf-03b4-e7009966283b"><div dir="ltr" style="margin-left:0pt;" align="center">
  | Event name | Properties | Notes
--- | -- | -- | --
  | screen_view | screen: qr |  
  | screen_leave | screen: qr |  
1 | mainmenu_tapped | screen: qr |  
2 | qr_header_share_tapped |   |  
3 | qr_header_expand_tapped |   |  
4 | qr_field_toggled | is_on: Bool; field: email |  
5 | qr_field_toggled | is_on: Bool; field: phone |  
6 | qr_field_toggled | is_on: Bool; field: name |  
7 | qr_field_toggled | is_on: Bool; field: location |  
8 | qr_field_toggled | is_on: Bool; field: job_title |  
9 | qr_field_toggled | is_on: Bool; field: company |  
10 | qr_field_toggled | is_on: Bool; field: about_me |  
11 | qr_field_toggled | is_on: Bool; field: profile_url |  
12 | qr_field_toggled | is_on: Bool; field: verified_account_{service} | 
13 | qr_preview_tapped |   |  
14 | qr_private_contact_info_button_tapped |   |  
</div><br /></b>

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-c501f2e1-7fff-06bd-3b82-c969aa0c826e"><div dir="ltr" style="margin-left:0pt;" align="center">
  | Event name | Properties | Notes
-- | -- | -- | --
  | screen_view | screen: qr_full_screen |  
  | screen_leave | screen: qr_full_screen |  
1 | qr_full_screen_close_button_tapped |   |  
</div><br /></b>

I've also improved the tracking logs to make the event parameters read easier in json:
<img width="1648" height="390" alt="CleanShot 2025-08-14 at 15 50 41@2x" src="https://github.com/user-attachments/assets/947c54c0-64e1-4a73-8fc3-267a08ceca50" />

And added `(Locally)` when the TrackerMock tracker is used in unit tests.
`🔹 Tracking (Locally): profile_fetch_success; properties: {}`

### To test:

- Check that the mentioned events are being tracked