### PR TITLE
Adding analytics for Main Menu

### DIFF
--- a/GravatarApp/CommonViews/MainMenu/AboutModalEvents.swift
+++ b/GravatarApp/CommonViews/MainMenu/AboutModalEvents.swift
@@ -1,0 +1,14 @@
+import Analytics
+
+enum AboutModalEvents {
+    static let screenView: AnalyticsEvent = AppEvent.screenView(screen: .about)
+    static let screenLeave: AnalyticsEvent = AppEvent.screenLeave(screen: .about)
+
+    static let supportLinkTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "about_support_link_button_tapped")
+    static let supportEmailTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "about_support_email_button_tapped")
+    static let tosTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "about_tos_button_tapped")
+    static let privacyPolicyTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "about_privacy_policy_button_tapped")
+    static let deleteAccountTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "about_delete_account_button_tapped")
+    static let deleteAccountWarningAccepted: AnalyticsEvent = CommonAnalyticsEvent(name: "about_delete_account_warning_accepted")
+    static let deleteAccountWarningCancelled: AnalyticsEvent = CommonAnalyticsEvent(name: "about_delete_account_warning_cancelled")
+}

--- a/GravatarApp/CommonViews/MainMenu/AboutView.swift
+++ b/GravatarApp/CommonViews/MainMenu/AboutView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import Analytics
+import SwiftUI
 
 struct AboutView: View {
     @EnvironmentObject var modalManager: ModalPresentationManager

--- a/GravatarApp/CommonViews/MainMenu/AboutView.swift
+++ b/GravatarApp/CommonViews/MainMenu/AboutView.swift
@@ -1,8 +1,11 @@
 import SwiftUI
+import Analytics
 
 struct AboutView: View {
     @EnvironmentObject var modalManager: ModalPresentationManager
+    @Environment(\.analytics) private var analytics
     @State private var inAppURL: URL?
+    @Environment(\.openURL) private var openURL
 
     @State private var presentAccountDeletionWarning: Bool = false
 
@@ -21,13 +24,29 @@ struct AboutView: View {
             }
             VStack(alignment: .leading) {
                 title(Localized.getHelpTitle)
-                link("support.gravatar.com", url: "https://support.gravatar.com")
-                link("support@gravatar.com", url: "mailto:support@gravatar.com")
+                link(
+                    "support.gravatar.com",
+                    url: "https://support.gravatar.com",
+                    event: AboutModalEvents.supportLinkTapped
+                )
+                link(
+                    "support@gravatar.com",
+                    url: "mailto:support@gravatar.com",
+                    event: AboutModalEvents.supportEmailTapped
+                )
             }
             VStack(alignment: .leading) {
                 title(Localized.legalTitle)
-                inAppSafariLink(Localized.termsOfServiceText, url: "https://automattic.com/tos/")
-                inAppSafariLink(Localized.privacyPolicyText, url: "https://automattic.com/privacy/")
+                inAppSafariLink(
+                    Localized.termsOfServiceText,
+                    url: "https://automattic.com/tos/",
+                    tracking: AboutModalEvents.tosTapped
+                )
+                inAppSafariLink(
+                    Localized.privacyPolicyText,
+                    url: "https://automattic.com/privacy/",
+                    tracking: AboutModalEvents.privacyPolicyTapped
+                )
             }
             VStack(alignment: .leading) {
                 title(Localized.deleteAccountTitle)
@@ -46,6 +65,12 @@ struct AboutView: View {
         }
         .padding()
         .presentSafariView(url: $inAppURL)
+        .onAppear {
+            analytics.track(AboutModalEvents.screenView)
+        }
+        .onDisappear {
+            analytics.track(AboutModalEvents.screenLeave)
+        }
     }
 
     private func title(_ text: String) -> some View {
@@ -55,9 +80,14 @@ struct AboutView: View {
             .padding(.bottom, .DS.Padding.half)
     }
 
-    private func link(_ text: String, url: String) -> some View {
-        Link(text, destination: URL(string: url)!)
-            .foregroundStyle(textColor)
+    private func link(_ text: String, url: String, event: AnalyticsEvent) -> some View {
+        Button {
+            analytics.track(event)
+            openURL(URL(string: url)!)
+        } label: {
+            Text(text)
+        }
+        .foregroundStyle(textColor)
     }
 
     private func label(_ text: String) -> some View {
@@ -67,6 +97,7 @@ struct AboutView: View {
 
     private var deleteAccountButton: some View {
         Button {
+            analytics.track(AboutModalEvents.deleteAccountTapped)
             presentAccountDeletionWarning = true
         } label: {
             Text(Localized.deleteAccountTitle)
@@ -75,15 +106,20 @@ struct AboutView: View {
         }
         .confirmationDialog(Localized.deleteAccountWarningTitle, isPresented: $presentAccountDeletionWarning, titleVisibility: .visible) {
             Button(Localized.deleteAccountTitle, role: .destructive) {
+                analytics.track(AboutModalEvents.deleteAccountWarningAccepted)
                 notificationCenter.post(name: .deleteAccount, object: nil)
+            }
+            Button(Localized.cancelTitle, role: .cancel) {
+                analytics.track(AboutModalEvents.deleteAccountWarningCancelled)
             }
         } message: {
             Text(Localized.deleteAccountWarningMessage)
         }
     }
 
-    private func inAppSafariLink(_ text: String, url: String) -> some View {
+    private func inAppSafariLink(_ text: String, url: String, tracking event: any AnalyticsEvent) -> some View {
         Button {
+            analytics.track(event)
             inAppURL = URL(string: url)
         } label: {
             Text(text)
@@ -140,6 +176,12 @@ private enum Localized {
         "AboutModal.accountDeletion.title",
         value: "Delete account",
         comment: "Title for the 'Delete account' section in the 'About Gravatar' view"
+    )
+
+    static let cancelTitle = NSLocalizedString(
+        "AboutModal.accountDeletion.cancel",
+        value: "Cancel",
+        comment: "Title for the 'Cancel' button when deleting an account in the 'About Gravatar' view"
     )
 
     static let deleteAccountMessage = NSLocalizedString(

--- a/GravatarApp/CommonViews/MainMenu/MainMenu.swift
+++ b/GravatarApp/CommonViews/MainMenu/MainMenu.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct MainMenu: View {
     @Environment(\.openURL) private var openURL
+    @Environment(\.analytics) private var analytics
     @EnvironmentObject private var modalManager: ModalPresentationManager
     @State private var shareProfileURL: URL?
     let onMenuAppear: (() -> Void)?
@@ -36,16 +37,20 @@ struct MainMenu: View {
         MenuSection {
             MenuItem(Localized.visitProfileTitle, systemImage: "safari") {
                 guard let url = URL(string: profile.profileUrl) else { return }
+                analytics.track(MainMenuEvents.visitProfileTapped)
                 openURL(url)
             }
             MenuItem(Localized.shareTitle, systemImage: "square.and.arrow.up") {
+                analytics.track(MainMenuEvents.shareProfileTapped)
                 shareProfileURL = profile.profileURL
             }
             MenuItem("Gravatar.com", systemImage: "globe") {
                 guard let url = URL(string: "https://gravatar.com") else { return }
+                analytics.track(MainMenuEvents.visitGravatarComTapped)
                 openURL(url)
             }
             MenuItem(Localized.aboutTitle, systemImage: "list.bullet.clipboard") {
+                analytics.track(MainMenuEvents.aboutTapped)
                 modalManager.present {
                     AboutView()
                 }
@@ -57,6 +62,7 @@ struct MainMenu: View {
                 systemImage: "iphone.and.arrow.forward.outward",
                 attributes: .destructive
             ) {
+                analytics.track(MainMenuEvents.signOutTapped)
                 notificationCenter.post(name: .signOut, object: nil)
             }
         }

--- a/GravatarApp/CommonViews/MainMenu/MainMenuEvents.swift
+++ b/GravatarApp/CommonViews/MainMenu/MainMenuEvents.swift
@@ -7,5 +7,3 @@ enum MainMenuEvents {
     static let aboutTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "mainmenu_about_button_tapped")
     static let signOutTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "mainmenu_signout_button_tapped")
 }
-
-

--- a/GravatarApp/CommonViews/MainMenu/MainMenuEvents.swift
+++ b/GravatarApp/CommonViews/MainMenu/MainMenuEvents.swift
@@ -1,0 +1,11 @@
+import Analytics
+
+enum MainMenuEvents {
+    static let visitProfileTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "mainmenu_visit_profile_button_tapped")
+    static let shareProfileTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "mainmenu_share_profile_button_tapped")
+    static let visitGravatarComTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "mainmenu_visit_gravatarcom_button_tapped")
+    static let aboutTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "mainmenu_about_button_tapped")
+    static let signOutTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "mainmenu_signout_button_tapped")
+}
+
+

--- a/GravatarAppTests/ModalsTests/AboutModalTests.swift
+++ b/GravatarAppTests/ModalsTests/AboutModalTests.swift
@@ -1,3 +1,4 @@
+import Analytics
 import Foundation
 @testable import GravatarApp
 import SnapshotTesting
@@ -12,6 +13,7 @@ struct AboutModalTests {
         let modalManager = ModalPresentationManager()
         modalManager.present {
             AboutView()
+                .environment(\.analytics, Analytics.test)
         }
 
         let view = Color.clear


### PR DESCRIPTION
Closes GRA-721

This PR adds Analytics events for Main Menu buttons and the About modal screen.

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-2bd4fedf-7fff-26b7-70ba-6b5ec64c3c47"><div dir="ltr" style="margin-left:0pt;" align="left">
1 | mainmenu_visit_profile_button_tapped |  
-- | -- | --
2 | mainmenu_share_profile_button_tapped |  
3 | mainmenu_visit_gravatarcom_button_tapped |  
4 | mainmenu_about_button_tapped |  
5 | mainmenu_signout_button_tapped |  

</div><br /></b>

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-022b74c1-7fff-77b4-a971-7e15ce687b43"><div dir="ltr" style="margin-left:0pt;" align="center">
  | Event name | Properties | Notes
-- | -- | -- | --
  | screen_view | screen: about |  
  | screen_leave | screen: about |  
1 | about_support_link_button_tapped |   |  
2 | about_support_email_button_tapped |   |  
3 | about_tos_button_tapped |   |  
4 | about_privacy_policy_button_tapped |   |  
5 | about_delete_account_button_tapped |   |  
  | about_delete_account_warning_accepted |   | Accepted to delete account
  | about_delete_account_warning_cancelled |   | Canceled account deletion

</div><br /></b>

### To test:

- Check that the events trigger as expected according with the event tables.