### PR TITLE
Rename Share tab to QR

### DIFF
--- a/GravatarApp/AppRoot/RootTabView.swift
+++ b/GravatarApp/AppRoot/RootTabView.swift
@@ -129,7 +129,7 @@ struct ShareTab: View {
         }
         .background(Color(uiColor: .secondarySystemBackground))
         .tabItem {
-            Label(Localized.shareTabTitle, image: .shareTab)
+            Label("QR", image: .shareTab)
         }
         .tag(RootTabItem.qr)
     }
@@ -153,12 +153,6 @@ private enum Localized {
         "Tabs.Profile.title",
         value: "Profile",
         comment: "Title for the profile tab"
-    )
-
-    static let shareTabTitle = NSLocalizedString(
-        "Tabs.Share.title",
-        value: "Share",
-        comment: "Title for the share tab"
     )
 }
 

--- a/GravatarApp/Resources/en.lproj/Localizable.strings
+++ b/GravatarApp/Resources/en.lproj/Localizable.strings
@@ -1,3 +1,13 @@
+/* Warning message for the 'Delete account' section in the 'About Gravatar' view */
+"AboutModal.accountDeletion.message" = "No longer using Gravatar? Delete your account here.";
+
+/* Title for the 'Delete account' section in the 'About Gravatar' view */
+"AboutModal.accountDeletion.title" = "Delete account";
+
+/* Detailed Title warning for the 'Delete account' action in the 'About Gravatar' view
+   Detailed warning message for the 'Delete account' section in the 'About Gravatar' view */
+"AboutModal.accountDeletion.warning.message" = "Deleting your Gravatar account will immediately prevent all access to your profile";
+
 /* Text for the 'Done' button in the 'About Gravatar' view */
 "AboutModal.CloseButton.title" = "Done";
 
@@ -241,8 +251,17 @@
 /* Title for the profile tab */
 "Tabs.Profile.title" = "Profile";
 
-/* Title for the share tab */
-"Tabs.Share.title" = "Share";
+/* Error message shown when an unknown error occurs while deleting an account */
+"Welcome.accountDeletion.unknownError" = "An unknown error has occurred while deleting your account";
+
+/* Title for the error when account deletion fails */
+"Welcome.Error.DeleteAccount.title" = "Error deleting account.";
+
+/* Title for the generic error alert */
+"Welcome.Error.NoInternet.message" = "Please check your connection before proceeding.";
+
+/* Title for the generic error alert */
+"Welcome.Error.NoInternet.title" = "No internet connection detected";
 
 /* Message for the error when OAuth is denied by the user. */
 "Welcome.Error.OAuth.Denied.message" = "You need to log in to Gravatar.com.";
@@ -256,6 +275,9 @@
 /* Title for the error when the profile fetch fails. */
 "Welcome.Error.Profile.title" = "Unable to load your profile.";
 
+/* Title for the generic error alert */
+"Welcome.Error.title" = "Error";
+
 /* Title for the button to login with another account. */
 "Welcome.Login.AnotherAccountButton.title" = "Try with another account";
 
@@ -267,4 +289,7 @@
 
 /* Subtitle for the login screen */
 "Welcome.Logo.subtitle" = "Your globally recognized avatar.";
+
+/* Error message shown when associated domain setup hasn't finished yet */
+"Welcome.OAuth.secureLoginErrorMessage" = "Setting up secure login… Please try again in a few seconds.";
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ check-docker:
 	@command -v docker >/dev/null 2>&1 || { echo "Error: Docker is not installed or not in PATH"; false; }
 	@docker info >/dev/null 2>&1 || { echo "Error: Docker is installed but not running or accessible by the current user"; false; }
 
+generate-strings: # Generates strings from source and commits the result
+	bundle exec fastlane generate_strings
+
+generate-strings-no-commit: # Generates strings from source without commits the result
+	bundle exec fastlane generate_strings skip_commit:true
+
 
 dump:  # Dump all derived values used by the Makefile.
 	@echo "CURRENT_MAKEFILE_PATH = $(CURRENT_MAKEFILE_PATH)"


### PR DESCRIPTION
Closes GRA-732

This PR changes the Share tab name to QR

I did some research and I found out that the `QR` as a technical acronym, is universal and doesn't need localization.

- I also took the chance to create a make command to generate strings from source
  - `make generate-strings` and `make generate-strings-no-commit` 
- And I've run it to update the localized strings file.

<img width="40%" alt="CleanShot 2025-08-14 at 23 09 25@2x" src="https://github.com/user-attachments/assets/ee700da8-180b-46b8-a6e3-130c722514e0" />

### To test:

- Run te app
- Check the `QR` tab name
