### PR TITLE
Adding small animation on avatar tap

### DIFF
--- a/GravatarApp/AvatarPicker/Avatar/AvatarPickerAvatarView.swift
+++ b/GravatarApp/AvatarPicker/Avatar/AvatarPickerAvatarView.swift
@@ -12,6 +12,7 @@ struct AvatarPickerAvatarView: View {
 
     @State private var uploadError: AvatarUploadErrorInfo?
     @State private var presentUploadErrorActions: Bool = false
+    @State private var isTapped: Bool = false
 
     var body: some View {
         AvatarView(
@@ -45,6 +46,8 @@ struct AvatarPickerAvatarView: View {
         .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(shouldSelect() ? .isSelected : [])
         .accessibilityLabel(Text(avatar.accessibilityLabel(altText: avatar.altText)))
+        .scaleEffect(isTapped ? 0.95 : 1.0)
+        .opacity(isTapped ? 0.8 : 1.0)
     }
 
     @ViewBuilder
@@ -77,7 +80,13 @@ struct AvatarPickerAvatarView: View {
         if avatarSelected {
             selectedCheckmarkView()
         }
-        AvatarActionsMenu(isAvatarSelected: avatarSelected, labelTapAction: tapAction) {
+        AvatarActionsMenu(isAvatarSelected: avatarSelected) {
+            isTapped = true
+            withAnimation(.smooth) {
+                isTapped = false
+            }
+            tapAction?()
+        } label: {
             Color.clear
         } onActionSelected: { action in
             onActionSelected(action)

--- a/GravatarApp/AvatarPicker/Avatar/AvatarPickerAvatarView.swift
+++ b/GravatarApp/AvatarPicker/Avatar/AvatarPickerAvatarView.swift
@@ -81,15 +81,19 @@ struct AvatarPickerAvatarView: View {
             selectedCheckmarkView()
         }
         AvatarActionsMenu(isAvatarSelected: avatarSelected) {
-            isTapped = true
-            withAnimation(.smooth) {
-                isTapped = false
-            }
+            runOnTapAnimation()
             tapAction?()
         } label: {
             Color.clear
         } onActionSelected: { action in
             onActionSelected(action)
+        }
+    }
+
+    private func runOnTapAnimation() {
+        isTapped = true
+        withAnimation(.smooth) {
+            isTapped = false
         }
     }
 


### PR DESCRIPTION
Closes GRA-666

This PR adds a small animation when an avatar in the grid is tapped. Since we don't have a `onMenuDisappear` event, we can't keep this state, so I decided to run the animation and finish it automatically.

This should help be sure of which avatar was tapped:

https://github.com/user-attachments/assets/d7826ece-3d41-4dd2-874f-14ec27892c2c

### To test:

- Tap on an avatar grid item
  - Check that the animation runs and it's smooth and helpful 

