### PR TITLE
Use sentry to log some errors

### DIFF
--- a/GravatarApp/Extensions/APIError+Extensions.swift
+++ b/GravatarApp/Extensions/APIError+Extensions.swift
@@ -7,10 +7,10 @@ extension APIError {
         case .responseError(reason: .URLSessionError(error: let error)):
             let error = error as NSError
             return error.domain == NSURLErrorDomain &&
-            (
-                error.code == NSURLErrorNotConnectedToInternet ||
-                error.code == NSURLErrorNetworkConnectionLost
-            )
+                (
+                    error.code == NSURLErrorNotConnectedToInternet ||
+                        error.code == NSURLErrorNetworkConnectionLost
+                )
         default:
             return false
         }

--- a/GravatarApp/Extensions/APIError+Extensions.swift
+++ b/GravatarApp/Extensions/APIError+Extensions.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Gravatar
+
+extension APIError {
+    var isNotConnectedToInternet: Bool {
+        switch self {
+        case .responseError(reason: .URLSessionError(error: let error)):
+            (error as NSError).domain == NSURLErrorDomain && (error as NSError).code == NSURLErrorNotConnectedToInternet
+        default:
+            false
+        }
+    }
+}

--- a/GravatarApp/Extensions/APIError+Extensions.swift
+++ b/GravatarApp/Extensions/APIError+Extensions.swift
@@ -5,9 +5,14 @@ extension APIError {
     var isNotConnectedToInternet: Bool {
         switch self {
         case .responseError(reason: .URLSessionError(error: let error)):
-            (error as NSError).domain == NSURLErrorDomain && (error as NSError).code == NSURLErrorNotConnectedToInternet
+            let error = error as NSError
+            return error.domain == NSURLErrorDomain &&
+            (
+                error.code == NSURLErrorNotConnectedToInternet ||
+                error.code == NSURLErrorNetworkConnectionLost
+            )
         default:
-            false
+            return false
         }
     }
 }

--- a/GravatarApp/Logging/CrashLogger.swift
+++ b/GravatarApp/Logging/CrashLogger.swift
@@ -2,6 +2,11 @@ import AutomatticRemoteLogging
 import SwiftData
 
 final class CrashLogger {
+    enum Key {
+        static let errorTypeKey = "error_type"
+        static let errorTagKey = "error_tag"
+    }
+
     private let crashLogging: CrashLoggingType
     private let dataProvider: AppCrashLoggingDataProvider
 
@@ -31,6 +36,10 @@ final class CrashLogger {
     func refreshUser() {
         guard crashLogging.isEnabled else { return }
         crashLogging.setNeedsDataRefresh()
+    }
+
+    func logError(_ error: Error, tags: [String: String] = [:]) {
+        crashLogging.logError(error, tags: tags)
     }
 }
 

--- a/GravatarApp/Logging/CrashLoggingType.swift
+++ b/GravatarApp/Logging/CrashLoggingType.swift
@@ -7,6 +7,7 @@ protocol CrashLoggingType {
     func startLogging() throws
     func stopLogging()
     func setNeedsDataRefresh()
+    func logError(_ error: Error, userInfo: [String: Any]?)
 }
 
 extension CrashLogging: CrashLoggingType {
@@ -20,5 +21,9 @@ extension CrashLogging: CrashLoggingType {
 
     func startLogging() throws {
         _ = try self.start()
+    }
+
+    func logError(_ error: Error, userInfo: [String: Any]?) {
+        logError(error, userInfo: userInfo, level: .error)
     }
 }

--- a/GravatarApp/Logging/CrashLoggingType.swift
+++ b/GravatarApp/Logging/CrashLoggingType.swift
@@ -7,7 +7,7 @@ protocol CrashLoggingType {
     func startLogging() throws
     func stopLogging()
     func setNeedsDataRefresh()
-    func logError(_ error: Error, userInfo: [String: Any]?)
+    func logError(_ error: Error, tags: [String: String])
 }
 
 extension CrashLogging: CrashLoggingType {
@@ -23,7 +23,7 @@ extension CrashLogging: CrashLoggingType {
         _ = try self.start()
     }
 
-    func logError(_ error: Error, userInfo: [String: Any]?) {
-        logError(error, userInfo: userInfo, level: .error)
+    func logError(_ error: Error, tags: [String: String] = [:]) {
+        logError(error, tags: tags, level: .error)
     }
 }

--- a/GravatarApp/Welcome/WelcomeScreenEvent.swift
+++ b/GravatarApp/Welcome/WelcomeScreenEvent.swift
@@ -7,9 +7,6 @@ enum WelcomeScreenEvent {
     static let oauthStart: AnalyticsEvent = CommonAnalyticsEvent(name: "oauth_start")
     static let oauthCancelled: AnalyticsEvent = CommonAnalyticsEvent(name: "oauth_cancelled")
     static let oauthSuccess: AnalyticsEvent = CommonAnalyticsEvent(name: "oauth_success")
-    static func oauthError(error: String) -> AnalyticsEvent {
-        CommonAnalyticsEvent(name: "oauth_error", properties: ErrorEventProperties(error: error))
-    }
 
     static let profileFetchStart: AnalyticsEvent = CommonAnalyticsEvent(name: "profile_fetch_start")
     static let profileFetchSuccess: AnalyticsEvent = CommonAnalyticsEvent(name: "profile_fetch_success")

--- a/GravatarApp/Welcome/WelcomeScreenEvent.swift
+++ b/GravatarApp/Welcome/WelcomeScreenEvent.swift
@@ -7,13 +7,8 @@ enum WelcomeScreenEvent {
     static let oauthStart: AnalyticsEvent = CommonAnalyticsEvent(name: "oauth_start")
     static let oauthCancelled: AnalyticsEvent = CommonAnalyticsEvent(name: "oauth_cancelled")
     static let oauthSuccess: AnalyticsEvent = CommonAnalyticsEvent(name: "oauth_success")
-
     static let profileFetchStart: AnalyticsEvent = CommonAnalyticsEvent(name: "profile_fetch_start")
     static let profileFetchSuccess: AnalyticsEvent = CommonAnalyticsEvent(name: "profile_fetch_success")
-    static func profileFetchError(error: String) -> AnalyticsEvent {
-        CommonAnalyticsEvent(name: "profile_fetch_error", properties: ErrorEventProperties(error: error))
-    }
-
     static let tabGravatarTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "tab_gravatar_tapped")
     static let tabProfileTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "tab_profile_tapped")
     static let tabQRTapped: AnalyticsEvent = CommonAnalyticsEvent(name: "tab_qr_tapped")

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -77,7 +77,9 @@ class WelcomeViewModel: ObservableObject {
             await configureSession(profile: profile, accessToken: token)
             cleanAllErrors()
         } catch {
-            if let error = error as? APIError { // Always the case (we need typed throws from the SDK)
+            if let error = error as? APIError, // Always the case (we need typed throws from the SDK)
+               !error.isNotConnectedToInternet // Not interested in connection errors
+            {
                 crashLogger.logError(error, tags: [
                     CrashLogger.Key.errorTypeKey: "profile_fetch_error",
                 ])

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -196,16 +196,26 @@ class WelcomeViewModel: ObservableObject {
                 analytics.track(WelcomeScreenEvent.oauthCancelled)
             case let error where error.isAssociatedDomainError:
                 oauthAlertErrorMessage = Localized.secureLoginErrorMessage
-                analytics.track(WelcomeScreenEvent.oauthError(error: error.errorDescription))
+                logOAuthError(error)
             default:
                 oauthAlertErrorMessage = error.errorDescription
-                analytics.track(WelcomeScreenEvent.oauthError(error: error.errorDescription))
+                logOAuthError(error)
             }
             withAnimation {
                 self.oauthError = error
             }
             isLoading = false
         }
+    }
+
+    private func logOAuthError(_ error: OAuthError) {
+        crashLogger.logError(
+            error,
+            tags: [
+                CrashLogger.Key.errorTypeKey: "oauth_error",
+                CrashLogger.Key.errorTagKey: error.errorTag,
+            ]
+        )
     }
 }
 

--- a/GravatarApp/Welcome/WelcomeViewModel.swift
+++ b/GravatarApp/Welcome/WelcomeViewModel.swift
@@ -78,7 +78,9 @@ class WelcomeViewModel: ObservableObject {
             cleanAllErrors()
         } catch {
             if let error = error as? APIError { // Always the case (we need typed throws from the SDK)
-                analytics.track(WelcomeScreenEvent.profileFetchError(error: error.debugDescription))
+                crashLogger.logError(error, tags: [
+                    CrashLogger.Key.errorTypeKey: "profile_fetch_error",
+                ])
             }
             localAccessToken = token
             withAnimation(.smooth(duration: 0.2)) {

--- a/GravatarAppTests/WelcomeTests/Helpers/CrashLoggingMock.swift
+++ b/GravatarAppTests/WelcomeTests/Helpers/CrashLoggingMock.swift
@@ -3,6 +3,7 @@
 class CrashLoggingMock: CrashLoggingType {
     var isEnabled: Bool = false
     var setNeedsDataRefreshCalled = false
+    var loggedError: (Error, [String: Any]?)?
 
     func stopLogging() {
         isEnabled = false
@@ -14,5 +15,9 @@ class CrashLoggingMock: CrashLoggingType {
 
     func setNeedsDataRefresh() {
         setNeedsDataRefreshCalled = true
+    }
+
+    func logError(_ error: any Error, userInfo: [String: Any]?) {
+        loggedError = (error, userInfo)
     }
 }

--- a/GravatarAppTests/WelcomeTests/Helpers/CrashLoggingMock.swift
+++ b/GravatarAppTests/WelcomeTests/Helpers/CrashLoggingMock.swift
@@ -3,7 +3,7 @@
 class CrashLoggingMock: CrashLoggingType {
     var isEnabled: Bool = false
     var setNeedsDataRefreshCalled = false
-    var loggedError: (Error, [String: String])?
+    var loggedErrors: [(error: Error, tags: [String: String])] = []
 
     func stopLogging() {
         isEnabled = false
@@ -18,6 +18,6 @@ class CrashLoggingMock: CrashLoggingType {
     }
 
     func logError(_ error: Error, tags: [String: String]) {
-        loggedError = (error, tags)
+        loggedErrors.append((error: error, tags: tags))
     }
 }

--- a/GravatarAppTests/WelcomeTests/Helpers/CrashLoggingMock.swift
+++ b/GravatarAppTests/WelcomeTests/Helpers/CrashLoggingMock.swift
@@ -3,7 +3,7 @@
 class CrashLoggingMock: CrashLoggingType {
     var isEnabled: Bool = false
     var setNeedsDataRefreshCalled = false
-    var loggedError: (Error, [String: Any]?)?
+    var loggedError: (Error, [String: String])?
 
     func stopLogging() {
         isEnabled = false
@@ -17,7 +17,7 @@ class CrashLoggingMock: CrashLoggingType {
         setNeedsDataRefreshCalled = true
     }
 
-    func logError(_ error: any Error, userInfo: [String: Any]?) {
-        loggedError = (error, userInfo)
+    func logError(_ error: Error, tags: [String: String]) {
+        loggedError = (error, tags)
     }
 }

--- a/GravatarAppTests/WelcomeTests/WelcomeViewModelTests.swift
+++ b/GravatarAppTests/WelcomeTests/WelcomeViewModelTests.swift
@@ -12,6 +12,7 @@ final class WelcomeViewModelTests {
     let profileService = TestProfileService()
     let oauthSession = TestOAuthSession(callbackURL: URL(string: "https://some.com")!)
     let tracker = TrackerMock()
+    let crashLoggingMock = CrashLoggingMock()
 
     lazy var oauthManager = OAuthManager(
         authenticationSession: oauthSession,
@@ -25,7 +26,7 @@ final class WelcomeViewModelTests {
         analytics: Analytics(tracker: tracker, userUUIDStorage: UserUUIDStorageMock()),
         profileService: profileService,
         context: container.mainContext,
-        crashLogger: CrashLogger(crashLogging: CrashLoggingMock(), context: .testContext)
+        crashLogger: CrashLogger(crashLogging: crashLoggingMock, context: .testContext)
     )
 
     init() async throws {
@@ -127,7 +128,8 @@ final class WelcomeViewModelTests {
         #expect(model.profileFetchingError != nil)
         #expect(model.oauthError == nil)
 
-        #expect(tracker.tracked(event: WelcomeScreenEvent.profileFetchError(error: "")))
+        #expect(crashLoggingMock.loggedErrors.first?.error as? APIError != nil)
+        #expect(crashLoggingMock.loggedErrors.first?.tags["error_type"] == "profile_fetch_error")
         #expect(tracker.tracked(event: WelcomeScreenEvent.profileFetchSuccess, count: 0))
     }
 

--- a/GravatarAppTests/WelcomeTests/WelcomeViewModelTests.swift
+++ b/GravatarAppTests/WelcomeTests/WelcomeViewModelTests.swift
@@ -133,6 +133,22 @@ final class WelcomeViewModelTests {
         #expect(tracker.tracked(event: WelcomeScreenEvent.profileFetchSuccess, count: 0))
     }
 
+    @Test("Connection errors should not be logged when fetching profile")
+    func profileErrorNoInternet() async throws {
+        profileService.error = .responseError(
+            reason: .URLSessionError(error: NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet))
+        )
+
+        await model.requestOAuthToken()
+
+        #expect(model.userSession == nil)
+        #expect(model.profileFetchingError != nil)
+        #expect(model.oauthError == nil)
+
+        #expect(crashLoggingMock.loggedErrors.count == 0)
+        #expect(tracker.tracked(event: WelcomeScreenEvent.profileFetchSuccess, count: 0))
+    }
+
     @Test("Profile error clears after successful profile request")
     func profileErrorClears() async throws {
         profileService.error = .responseError(

--- a/GravatarAppTests/WelcomeTests/WelcomeViewModelTests.swift
+++ b/GravatarAppTests/WelcomeTests/WelcomeViewModelTests.swift
@@ -133,10 +133,10 @@ final class WelcomeViewModelTests {
         #expect(tracker.tracked(event: WelcomeScreenEvent.profileFetchSuccess, count: 0))
     }
 
-    @Test("Connection errors should not be logged when fetching profile")
-    func profileErrorNoInternet() async throws {
+    @Test("Connection errors should not be logged when fetching profile", arguments: [NSURLErrorNotConnectedToInternet, NSURLErrorNetworkConnectionLost])
+    func profileErrorNoInternet(errorCode: Int) async throws {
         profileService.error = .responseError(
-            reason: .URLSessionError(error: NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet))
+            reason: .URLSessionError(error: NSError(domain: NSURLErrorDomain, code: errorCode))
         )
 
         await model.requestOAuthToken()

--- a/Packages/OAuth/Sources/OAuth/OAuthError.swift
+++ b/Packages/OAuth/Sources/OAuth/OAuthError.swift
@@ -58,6 +58,32 @@ public enum OAuthError: Error {
             "Unknown error"
         }
     }
+
+    public var errorTag: String {
+        if isAssociatedDomainError {
+            return "associatedDomainError"
+        }
+        switch self {
+        case .couldNotParseAccessCode:
+            return "couldNotParseAccessCode"
+        case .oauthResponseError:
+            return "oauthResponseError"
+        case .tokenRequestError:
+            return "tokenRequestError"
+        case .tokenResponseError:
+            return "tokenResponseError"
+        case .decodingError:
+            return "decodingError"
+        case .unknown:
+            return "unknown"
+        case .notConfigured:
+            return "notConfigured"
+        case .configurationError:
+            return "configurationError"
+        default:
+            return "Uncategorized error"
+        }
+    }
 }
 
 extension OAuthError {


### PR DESCRIPTION
Closes GRA-751

## Description

Removing `oauth_error` and `profile_fetch_error` analytics events in favor of Sentry error logging.

Some interesting findings about Sentry:

1. I wanted to initially use `func logError(_ error: Error, userInfo: [String: Any]? = nil, level: SentryLevel = .error)` to put the already existing error description into the userInfo, but it gets removed due to scrubbing rules that we don't control.
 
<img width="467" height="218" alt="Screenshot 2025-08-19 at 12 46 06" src="https://github.com/user-attachments/assets/44d92a85-4fb7-47df-922b-551e9a212538" />

I also tried using the "tags" to add the error description but somehow it also doesn't work, the tag doesn't appear. Maybe there's a max length rule or something.

That said, Sentry already does a good job capturing the contents of the Error so hopefully we won't need the extra info.

2. I see only 1 row for different kinds of errors `oauth_error` and `profile_fetch_error`, so I added the tags to be able to query them easily. Tags enable us to do this:

<img width="723" height="287" alt="Screenshot 2025-08-19 at 13 06 52" src="https://github.com/user-attachments/assets/22e9942e-3f09-4908-af58-cf249023b834" />
  
## To test

I used the RELEASE config since we don't send the logs to Sentry in DEBUG.

**Test 1 - `oauth_error`**

I enabled the Network Link Conditioner and set it to "Very bad network"
Removed the app from the sim
Reinstalled and quickly tapped to login
Observe that you see the "Setting up secure login… " alert

Wait for 15 seconds and restart
You should see this error being added to Sentry
Remember to disable the network link conditioner

**Test 2 - `profile_fetch_error`**

I used Proxyman's breakpoints to interrupt and abort the profile fetching service
Try logging in and simulate the profile fetch error
Wait for 15 seconds and restart
You should see this error being added to Sentry