### PR TITLE
Fix `AboutModalTests` unit tests

### DIFF
--- a/GravatarApp/CommonViews/MainMenu/AboutView.swift
+++ b/GravatarApp/CommonViews/MainMenu/AboutView.swift
@@ -12,9 +12,11 @@ struct AboutView: View {
 
     private let textColor = Color.primary.opacity(0.6)
     private let notificationCenter: NotificationCenter
+    private let bundle: Bundle
 
-    init(notificationCenter: NotificationCenter = .default) {
+    init(notificationCenter: NotificationCenter = .default, bundle: Bundle = .main) {
         self.notificationCenter = notificationCenter
+        self.bundle = bundle
     }
 
     var body: some View {
@@ -141,7 +143,7 @@ struct AboutView: View {
     }
 
     func getAppVersion() -> String {
-        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+        if let appVersion = bundle.infoDictionary?["CFBundleShortVersionString"] as? String {
             return appVersion
         }
         return "?"

--- a/GravatarAppTests/ModalsTests/AboutModalTests.swift
+++ b/GravatarAppTests/ModalsTests/AboutModalTests.swift
@@ -5,14 +5,27 @@ import SnapshotTesting
 import SwiftUI
 import Testing
 
+// Mock Bundle for testing that provides consistent version info
+class MockBundle: Bundle {
+    override var infoDictionary: [String: Any]? {
+        [
+            "CFBundleShortVersionString": "1.0.0",
+        ]
+    }
+}
+
 @Suite(.snapshots(record: .failed, diffTool: .ksdiff))
 @MainActor
 struct AboutModalTests {
     @Test()
     func AboutModal() async throws {
         let modalManager = ModalPresentationManager()
+
+        // Create a mock bundle with version info for testing
+        let mockBundle = MockBundle()
+
         modalManager.present {
-            AboutView()
+            AboutView(bundle: mockBundle)
                 .environment(\.analytics, Analytics.test)
         }
 


### PR DESCRIPTION
The `AboutModalTests` tests seemed to have started failing after https://github.com/Automattic/Gravatar-iOS/pull/117.

That change made the Marketing Version to have an actual value in the tests target, and I believe reading `Bundle.main` won't have the right result (`Bundle.main` will refer to the test bundle, which doesn't have the same `Info.plist` configuration as the app bundle).

CI should be 🟢 